### PR TITLE
merge: (#28) User 설계 오류 수정

### DIFF
--- a/simtong-application/src/main/kotlin/team/comit/simtong/domain/user/usecase/SignUpUseCase.kt
+++ b/simtong-application/src/main/kotlin/team/comit/simtong/domain/user/usecase/SignUpUseCase.kt
@@ -26,7 +26,7 @@ class SignUpUseCase(
         val user = saveUserPort.saveUser(signUpPolicy.implement(request))
 
         return receiveTokenPort.generateJsonWebToken(
-            userId = user.id!!,
+            userId = user.id,
             authority = user.authority
         )
     }

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/user/model/User.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/user/model/User.kt
@@ -1,11 +1,11 @@
 package team.comit.simtong.domain.user.model
 
 import team.comit.simtong.global.annotation.Aggregate
-import java.util.UUID
+import java.util.*
 
 /**
  *
- * Root Aggregate를 담당하는 User
+ * UserAggregate Root를 담당하는 User
  *
  * @author Chokyunghyeon
  * @date 2022/09/04
@@ -13,7 +13,7 @@ import java.util.UUID
  **/
 @Aggregate
 data class User(
-    val id: UUID?,
+    val id: UUID = UUID(0, 0),
 
     val nickname: String,
 
@@ -27,7 +27,7 @@ data class User(
 
     val authority: Authority,
 
-    val adminCode: String?,
+    val adminCode: String? = null,
 
     val profileImagePath: String
 ) {

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/user/policy/SignUpPolicy.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/user/policy/SignUpPolicy.kt
@@ -30,14 +30,12 @@ class SignUpPolicy(
         // 임직원 확인
 
         return User(
-            id = null,
             name = request.name,
             email = request.email,
             password = securityPort.encode(request.password),
             nickname = request.nickname ?: "", // nickNamePort.random()
             employeeNumber = request.employeeNumber,
             authority = Authority.ROLE_COMMON,
-            adminCode = null,
             profileImagePath = request.profileImagePath ?: User.defaultImage
         )
     }

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/BaseEntity.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/BaseEntity.kt
@@ -1,7 +1,9 @@
 package team.comit.simtong.persistence
 
+import org.hibernate.annotations.GenericGenerator
 import java.util.*
 import javax.persistence.Column
+import javax.persistence.GeneratedValue
 import javax.persistence.Id
 import javax.persistence.MappedSuperclass
 
@@ -16,6 +18,8 @@ import javax.persistence.MappedSuperclass
 @MappedSuperclass
 abstract class BaseEntity(
     @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
     @Column(columnDefinition = "BINARY(16)")
-    val id: UUID = UUID.randomUUID()
+    val id: UUID?
 ) : BaseTimeEntity()

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/BaseTimeEntity.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/BaseTimeEntity.kt
@@ -1,8 +1,8 @@
 package team.comit.simtong.persistence
 
 import java.time.LocalDateTime
+import javax.persistence.Column
 import javax.persistence.MappedSuperclass
-import javax.validation.constraints.NotNull
 
 /**
  *
@@ -14,6 +14,6 @@ import javax.validation.constraints.NotNull
  **/
 @MappedSuperclass
 abstract class BaseTimeEntity(
-    @field:NotNull
+    @Column(nullable = false, updatable = false)
     val createdAt: LocalDateTime = LocalDateTime.now(),
 )

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/BaseUUIDEntity.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/BaseUUIDEntity.kt
@@ -1,7 +1,9 @@
 package team.comit.simtong.persistence
 
+import org.hibernate.annotations.GenericGenerator
 import java.util.*
 import javax.persistence.Column
+import javax.persistence.GeneratedValue
 import javax.persistence.Id
 import javax.persistence.MappedSuperclass
 
@@ -16,6 +18,8 @@ import javax.persistence.MappedSuperclass
 @MappedSuperclass
 abstract class BaseUUIDEntity(
     @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
     @Column(columnDefinition = "BINARY(16)")
-    val id: UUID = UUID.randomUUID()
+    val id: UUID?
 )

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/spot/entity/SpotJpaEntity.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/spot/entity/SpotJpaEntity.kt
@@ -2,6 +2,7 @@ package team.comit.simtong.persistence.spot.entity
 
 import org.hibernate.validator.constraints.Length
 import team.comit.simtong.persistence.BaseUUIDEntity
+import java.util.*
 import javax.persistence.Entity
 import javax.persistence.Table
 import javax.validation.constraints.NotNull
@@ -17,6 +18,7 @@ import javax.validation.constraints.NotNull
 @Entity
 @Table(name = "tbl_spot")
 class SpotJpaEntity(
+    override val id: UUID?,
 
     @field:NotNull
     @field:Length(max = 20)
@@ -25,4 +27,4 @@ class SpotJpaEntity(
     @field:NotNull
     @field:Length(max = 40)
     val location: String
-) : BaseUUIDEntity()
+) : BaseUUIDEntity(id)

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/team/entity/TeamJpaEntity.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/team/entity/TeamJpaEntity.kt
@@ -3,6 +3,7 @@ package team.comit.simtong.persistence.team.entity
 import org.hibernate.validator.constraints.Length
 import team.comit.simtong.persistence.BaseUUIDEntity
 import team.comit.simtong.persistence.spot.entity.SpotJpaEntity
+import java.util.*
 import javax.persistence.Entity
 import javax.persistence.FetchType
 import javax.persistence.JoinColumn
@@ -21,6 +22,7 @@ import javax.validation.constraints.NotNull
 @Entity
 @Table(name = "tbl_team")
 class TeamJpaEntity(
+    override val id: UUID?,
 
     @field:NotNull
     @field:Length(max = 8)
@@ -29,4 +31,4 @@ class TeamJpaEntity(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "spot_id", columnDefinition = "BINARY(16)", nullable = false)
     val spot: SpotJpaEntity,
-) : BaseUUIDEntity()
+) : BaseUUIDEntity(id)

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/user/entity/UserJpaEntity.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/user/entity/UserJpaEntity.kt
@@ -5,6 +5,7 @@ import org.hibernate.validator.constraints.Length
 import team.comit.simtong.domain.user.model.Authority
 import team.comit.simtong.persistence.BaseEntity
 import java.time.LocalDateTime
+import java.util.*
 import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.EnumType
@@ -23,6 +24,7 @@ import javax.validation.constraints.NotNull
 @Entity
 @Table(name = "tbl_user")
 class UserJpaEntity(
+    override val id: UUID?,
 
     @field:NotNull
     @Column(unique = true)
@@ -51,11 +53,11 @@ class UserJpaEntity(
     val password: String,
 
     @Column(columnDefinition = "CHAR(60)")
-    val adminCode: String,
+    val adminCode: String?,
 
     @field:NotNull
     @ColumnDefault("'default image'") // TODO 기본 프로필 이미지 설정
     val profileImagePath: String,
 
     val deletedAt: LocalDateTime?
-) : BaseEntity()
+) : BaseEntity(id)


### PR DESCRIPTION
## 작업 내용 설명
- [x] User Entity UUID 문제

## 주요 변경 사항
- User Aggregate의 id non-null
- BaseEntity, BaseUUIDEntity의 UUID 생성 방식
- BaseTimeEntity의 createdAt 컬럼 수정 방지

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #28 