### PR TITLE
merge: (#32) 로그인 기능

### DIFF
--- a/simtong-application/src/main/kotlin/team/comit/simtong/domain/user/spi/QueryUserPort.kt
+++ b/simtong-application/src/main/kotlin/team/comit/simtong/domain/user/spi/QueryUserPort.kt
@@ -1,19 +1,22 @@
 package team.comit.simtong.domain.user.spi
 
 import team.comit.simtong.domain.user.model.User
-import java.util.UUID
+import java.util.*
 
 /**
  *
  * User에 관한 Query를 요청하는 QueryUserPort
  *
  * @author Chokyunghyeon
+ * @author kimbeomjin
  * @date 2022/09/04
  * @version 1.0.0
  **/
 interface QueryUserPort {
 
     fun queryUserById(id: UUID): User
+
+    fun queryUserByEmployeeNumber(employeeNumber: Int): User
 
     fun queryUserByEmail(email: String): User
 

--- a/simtong-application/src/main/kotlin/team/comit/simtong/domain/user/usecase/SignInUseCase.kt
+++ b/simtong-application/src/main/kotlin/team/comit/simtong/domain/user/usecase/SignInUseCase.kt
@@ -1,0 +1,40 @@
+package team.comit.simtong.domain.user.usecase
+
+import team.comit.simtong.domain.auth.spi.ReceiveTokenPort
+import team.comit.simtong.domain.auth.usecase.dto.TokenResponse
+import team.comit.simtong.domain.user.exception.DifferentPasswordException
+import team.comit.simtong.domain.user.model.Authority
+import team.comit.simtong.domain.user.spi.QueryUserPort
+import team.comit.simtong.domain.user.spi.SecurityPort
+import team.comit.simtong.domain.user.usecase.dto.SignInRequest
+import team.comit.simtong.global.annotation.UseCase
+
+/**
+ *
+ * 사용자의 로그인 기능을 담당하는 SignInUseCase
+ *
+ * @author kimbeomjin
+ * @date 2022/09/08
+ * @version 1.0.0
+ **/
+@UseCase
+class SignInUseCase(
+    private val queryUserPort: QueryUserPort,
+    private val securityPort: SecurityPort,
+    private val tokenPort: ReceiveTokenPort
+) {
+
+    fun execute(request: SignInRequest): TokenResponse {
+        val user = queryUserPort.queryUserByEmployeeNumber(request.employeeNumber)
+
+        if (!securityPort.compare(request.password, user.password)) {
+            throw DifferentPasswordException.EXCEPTION
+        }
+
+        return tokenPort.generateJsonWebToken(
+            userId = user.id,
+            authority = Authority.ROLE_COMMON
+        )
+    }
+
+}

--- a/simtong-application/src/main/kotlin/team/comit/simtong/domain/user/usecase/dto/SignInRequest.kt
+++ b/simtong-application/src/main/kotlin/team/comit/simtong/domain/user/usecase/dto/SignInRequest.kt
@@ -1,0 +1,15 @@
+package team.comit.simtong.domain.user.usecase.dto
+
+/**
+ *
+ * 로그인을 정보를 전달하는 SignInRequest
+ *
+ * @author kimbeomjin
+ * @date 2022/09/08
+ * @version 1.0.0
+ **/
+data class SignInRequest(
+    val employeeNumber: Int,
+
+    val password: String
+)

--- a/simtong-application/src/test/kotlin/team/comit/simtong/user/usecase/SignInUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/user/usecase/SignInUseCaseTests.kt
@@ -1,0 +1,106 @@
+package team.comit.simtong.user.usecase
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.BDDMockito.given
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.auth.spi.ReceiveTokenPort
+import team.comit.simtong.domain.auth.usecase.dto.TokenResponse
+import team.comit.simtong.domain.user.exception.DifferentPasswordException
+import team.comit.simtong.domain.user.model.Authority
+import team.comit.simtong.domain.user.model.User
+import team.comit.simtong.domain.user.spi.QueryUserPort
+import team.comit.simtong.domain.user.spi.SecurityPort
+import team.comit.simtong.domain.user.usecase.SignInUseCase
+import team.comit.simtong.domain.user.usecase.dto.SignInRequest
+import java.util.*
+
+@ExtendWith(SpringExtension::class)
+class SignInUseCaseTests {
+
+
+    @MockBean
+    private lateinit var queryUserPort: QueryUserPort
+
+    @MockBean
+    private lateinit var securityPort: SecurityPort
+
+    @MockBean
+    private lateinit var tokenPort: ReceiveTokenPort
+
+    private lateinit var signInUseCase: SignInUseCase
+
+    private val employeeNumber: Int = 1234567891
+
+    private val userStub: User by lazy {
+        User(
+            id = UUID.randomUUID(),
+            nickname = "test nickname",
+            name = "test name",
+            email = "test@test.com",
+            password = "\$2a\$10\$.av8Mef703TEdRsGqoLcIe4esR6v0JfwpO9fBfH8bgZGrJYvQ0oBa",
+            employeeNumber = employeeNumber,
+            authority = Authority.ROLE_COMMON,
+            profileImagePath = "test path"
+        )
+    }
+
+    private val requestStub: SignInRequest by lazy {
+        SignInRequest(
+            employeeNumber = employeeNumber,
+            password = "rlaqjawls1-"
+        )
+    }
+
+    private val responseStub: TokenResponse by lazy {
+        TokenResponse(
+            accessToken = "test access token",
+            accessTokenExp = Date(),
+            refreshToken = "test refresh token"
+        )
+    }
+
+    @BeforeEach
+    fun setUp() {
+        signInUseCase = SignInUseCase(queryUserPort, securityPort, tokenPort)
+    }
+
+    @Test
+    fun `로그인 성공`() {
+        // given
+        given(queryUserPort.queryUserByEmployeeNumber(employeeNumber))
+            .willReturn(userStub)
+
+        given(securityPort.compare(requestStub.password, userStub.password))
+            .willReturn(true)
+
+        given(tokenPort.generateJsonWebToken(userStub.id, userStub.authority))
+            .willReturn(responseStub)
+
+        // when
+        val response = signInUseCase.execute(requestStub)
+
+        // then
+        assertThat(response).isEqualTo(responseStub)
+    }
+
+    @Test
+    fun `비밀번호 불일치`() {
+        // given
+        given(queryUserPort.queryUserByEmployeeNumber(employeeNumber))
+            .willReturn(userStub)
+
+        given(securityPort.compare(requestStub.password, userStub.password))
+            .willReturn(false)
+
+        // when then
+        assertThrows<DifferentPasswordException> {
+            signInUseCase.execute(requestStub)
+        }
+    }
+
+}

--- a/simtong-application/src/test/kotlin/team/comit/simtong/user/usecase/SignInUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/user/usecase/SignInUseCaseTests.kt
@@ -22,7 +22,6 @@ import java.util.*
 @ExtendWith(SpringExtension::class)
 class SignInUseCaseTests {
 
-
     @MockBean
     private lateinit var queryUserPort: QueryUserPort
 
@@ -42,7 +41,7 @@ class SignInUseCaseTests {
             nickname = "test nickname",
             name = "test name",
             email = "test@test.com",
-            password = "\$2a\$10\$.av8Mef703TEdRsGqoLcIe4esR6v0JfwpO9fBfH8bgZGrJYvQ0oBa",
+            password = "test password",
             employeeNumber = employeeNumber,
             authority = Authority.ROLE_COMMON,
             profileImagePath = "test path"
@@ -52,7 +51,7 @@ class SignInUseCaseTests {
     private val requestStub: SignInRequest by lazy {
         SignInRequest(
             employeeNumber = employeeNumber,
-            password = "rlaqjawls1-"
+            password = "test password"
         )
     }
 
@@ -97,7 +96,7 @@ class SignInUseCaseTests {
         given(securityPort.compare(requestStub.password, userStub.password))
             .willReturn(false)
 
-        // when then
+        // when & then
         assertThrows<DifferentPasswordException> {
             signInUseCase.execute(requestStub)
         }

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/user/error/UserErrorCode.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/user/error/UserErrorCode.kt
@@ -7,6 +7,7 @@ import team.comit.simtong.global.error.ErrorProperty
  * User에 대해 발생하는 Error를 관리하는 UserErrorCode
  *
  * @author Chokyunghyeon
+ * @author kimbeomjin
  * @date 2022/09/04
  * @version 1.0.0
  **/
@@ -15,9 +16,14 @@ enum class UserErrorCode(
     private val message: String
 ): ErrorProperty {
 
-    ALREADY_USED_EMAIL(409, "이미 사용된 이메일"),
+    // 401
+    DIFFERENT_PASSWORD(401, "비밀번호가 일치하지 않음"),
 
-    USER_NOT_FOUND(401, "유저를 찾을 수 없음");
+    // 404
+    USER_NOT_FOUND(404, "유저를 찾을 수 없음"),
+
+    // 409
+    ALREADY_USED_EMAIL(409, "이미 사용된 이메일");
 
     override fun status(): Int = status
 

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/user/exception/DifferentPasswordException.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/user/exception/DifferentPasswordException.kt
@@ -1,0 +1,21 @@
+package team.comit.simtong.domain.user.exception
+
+import team.comit.simtong.domain.user.error.UserErrorCode
+import team.comit.simtong.global.error.BusinessException
+
+/**
+ *
+ * Different Password Error를 발생시키는 DifferentPasswordException
+ *
+ * @author kimbeomjin
+ * @date 2022/09/08
+ * @version 1.0.0
+ **/
+class DifferentPasswordException private constructor() : BusinessException(UserErrorCode.DIFFERENT_PASSWORD) {
+
+    companion object {
+        @JvmField
+        val EXCEPTION = DifferentPasswordException()
+    }
+
+}

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/global/filter/ExceptionFilter.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/global/filter/ExceptionFilter.kt
@@ -31,12 +31,14 @@ class ExceptionFilter(
     ) {
         try {
             filterChain.doFilter(request, response)
-        } catch (exception: Exception) {
-            when (exception) {
-                is BusinessException -> writeErrorCode(exception.exceptionProperty, response)
+        } catch (e: BusinessException) {
+            writeErrorCode(e.exceptionProperty, response)
+        } catch (e: Exception) {
+            when (e.cause) {
+                is BusinessException -> writeErrorCode((e.cause as BusinessException).exceptionProperty, response)
                 else -> {
+                    e.printStackTrace()
                     writeErrorCode(InternalServerErrorException.EXCEPTION.exceptionProperty, response)
-                    exception.printStackTrace()
                 }
             }
         }

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/global/security/SecurityConfig.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/global/security/SecurityConfig.kt
@@ -40,7 +40,11 @@ class SecurityConfig(
 
         http
             .authorizeRequests()
+
+            // users
             .antMatchers(HttpMethod.POST, "/users").permitAll()
+            .antMatchers(HttpMethod.POST, "/users/tokens").permitAll()
+
             .anyRequest().authenticated()
 
         http

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/user/UserJpaProvider.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/user/UserJpaProvider.kt
@@ -1,0 +1,38 @@
+package team.comit.simtong.persistence.user
+
+import org.springframework.stereotype.Component
+import team.comit.simtong.domain.user.exception.UserNotFoundException
+import team.comit.simtong.persistence.user.entity.UserJpaEntity
+import java.util.*
+
+/**
+ *
+ * JPA를 통해 DB로부터 정보를 조회하고 가공하는 UserJpaProvider
+ *
+ * @author kimbeomjin
+ * @date 2022/09/08
+ * @version 1.0.0
+ **/
+@Component
+class UserJpaProvider(
+    private val userJpaRepository: UserJpaRepository
+) {
+
+    fun queryUserEntityById(id: UUID): UserJpaEntity {
+        return userJpaRepository.queryUserJpaEntityById(id) ?: throw UserNotFoundException.EXCEPTION
+    }
+
+    fun queryUserEntityByEmail(email: String): UserJpaEntity {
+        return userJpaRepository.queryUserJpaEntityByEmail(email) ?: throw UserNotFoundException.EXCEPTION
+    }
+
+    fun queryUserEntityByNickName(nickName: String): UserJpaEntity {
+        return userJpaRepository.queryUserJpaEntityByNickname(nickName) ?: throw UserNotFoundException.EXCEPTION
+    }
+
+    fun queryUserEntityByEmployeeNumber(employeeNumber: Int): UserJpaEntity {
+        return userJpaRepository.queryUserJpaEntityByEmployeeNumber(employeeNumber)
+            ?: throw UserNotFoundException.EXCEPTION
+    }
+
+}

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/user/UserJpaRepository.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/user/UserJpaRepository.kt
@@ -20,6 +20,8 @@ interface UserJpaRepository : CrudRepository<UserJpaEntity, UUID> {
 
     fun queryUserJpaEntityById(id: UUID): UserJpaEntity?
 
+    fun queryUserJpaEntityByEmployeeNumber(employeeNumber: Int): UserJpaEntity?
+
     fun queryUserJpaEntityByEmail(email: String): UserJpaEntity?
 
     fun queryUserJpaEntityByNickname(nickName: String): UserJpaEntity?

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/user/UserPersistenceAdapter.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/user/UserPersistenceAdapter.kt
@@ -1,11 +1,9 @@
 package team.comit.simtong.persistence.user
 
 import org.springframework.stereotype.Component
+import team.comit.simtong.domain.user.model.User
 import team.comit.simtong.domain.user.spi.QueryUserPort
 import team.comit.simtong.domain.user.spi.SaveUserPort
-import team.comit.simtong.domain.user.exception.UserNotFoundException
-import team.comit.simtong.domain.user.model.User
-import team.comit.simtong.persistence.user.entity.UserJpaEntity
 import team.comit.simtong.persistence.user.mapper.UserMapper
 import java.util.*
 
@@ -14,24 +12,38 @@ import java.util.*
  * User의 영속성을 관리하는 UserPersistenceAdapter
  *
  * @author Chokyunghyeon
+ * @author kimbeomjin
  * @date 2022/09/04
  * @version 1.0.0
  **/
 @Component
 class UserPersistenceAdapter(
     private val userJpaRepository: UserJpaRepository,
+    private val userJpaProvider: UserJpaProvider,
     private val userMapper: UserMapper
-): QueryUserPort, SaveUserPort {
+) : QueryUserPort, SaveUserPort {
     override fun queryUserById(id: UUID): User {
-        return userMapper.toDomain(queryUserEntityById(id))
+        return userMapper.toDomain(
+            userJpaProvider.queryUserEntityById(id)
+        )
+    }
+
+    override fun queryUserByEmployeeNumber(employeeNumber: Int): User {
+        return userMapper.toDomain(
+            userJpaProvider.queryUserEntityByEmployeeNumber(employeeNumber)
+        )
     }
 
     override fun queryUserByEmail(email: String): User {
-        return userMapper.toDomain(queryUserEntityByEmail(email))
+        return userMapper.toDomain(
+            userJpaProvider.queryUserEntityByEmail(email)
+        )
     }
 
     override fun queryUserByNickName(nickName: String): User {
-        return userMapper.toDomain(queryUserEntityByNickName(nickName))
+        return userMapper.toDomain(
+            userJpaProvider.queryUserEntityByNickName(nickName)
+        )
     }
 
     override fun existsUserByEmail(email: String): Boolean {
@@ -42,18 +54,6 @@ class UserPersistenceAdapter(
         val entity = userJpaRepository.save(userMapper.toEntity(user))
 
         return userMapper.toDomain(entity)
-    }
-
-    fun queryUserEntityById(id: UUID): UserJpaEntity {
-        return userJpaRepository.queryUserJpaEntityById(id) ?: throw UserNotFoundException.EXCEPTION
-    }
-
-    fun queryUserEntityByEmail(email: String): UserJpaEntity {
-        return userJpaRepository.queryUserJpaEntityByEmail(email) ?: throw UserNotFoundException.EXCEPTION
-    }
-
-    fun queryUserEntityByNickName(nickName: String): UserJpaEntity {
-        return userJpaRepository.queryUserJpaEntityByNickname(nickName) ?: throw UserNotFoundException.EXCEPTION
     }
 
 }

--- a/simtong-presentation/src/main/kotlin/team/comit/simtong/domain/user/WebUserAdapter.kt
+++ b/simtong-presentation/src/main/kotlin/team/comit/simtong/domain/user/WebUserAdapter.kt
@@ -7,9 +7,12 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import team.comit.simtong.domain.auth.usecase.dto.TokenResponse
-import team.comit.simtong.domain.user.dto.request.WebSignUpRequest
-import team.comit.simtong.domain.user.usecase.SignUpUseCase
 import team.comit.simtong.domain.user.dto.DomainSignUpRequest
+import team.comit.simtong.domain.user.dto.request.WebSignInRequest
+import team.comit.simtong.domain.user.dto.request.WebSignUpRequest
+import team.comit.simtong.domain.user.usecase.SignInUseCase
+import team.comit.simtong.domain.user.usecase.SignUpUseCase
+import team.comit.simtong.domain.user.usecase.dto.SignInRequest
 import javax.validation.Valid
 
 /**
@@ -17,13 +20,15 @@ import javax.validation.Valid
  * User에 관한 요청을 받는 WebUserAdapter
  *
  * @author Chokyunghyeon
+ * @author kimbeomjin
  * @date 2022/09/04
  * @version 1.0.0
  **/
 @RestController
 @RequestMapping("/users")
 class WebUserAdapter(
-    private val signUpUseCase: SignUpUseCase
+    private val signUpUseCase: SignUpUseCase,
+    private val signInUseCase: SignInUseCase
 ) {
 
     @ResponseStatus(HttpStatus.CREATED)
@@ -37,6 +42,16 @@ class WebUserAdapter(
                 nickname = request.nickname,
                 profileImagePath = request.profileImagePath,
                 employeeNumber = request.employeeNumber
+            )
+        )
+    }
+
+    @PostMapping("/tokens")
+    fun signIn(@Valid @RequestBody request: WebSignInRequest): TokenResponse {
+        return signInUseCase.execute(
+            SignInRequest(
+                employeeNumber = request.employeeNumber,
+                password = request.password
             )
         )
     }

--- a/simtong-presentation/src/main/kotlin/team/comit/simtong/domain/user/dto/request/WebSignInRequest.kt
+++ b/simtong-presentation/src/main/kotlin/team/comit/simtong/domain/user/dto/request/WebSignInRequest.kt
@@ -1,0 +1,22 @@
+package team.comit.simtong.domain.user.dto.request
+
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotEmpty
+import javax.validation.constraints.NotNull
+
+/**
+ *
+ * 로그인을 요청하는 WebSignInRequest
+ *
+ * @author kimbeomjin
+ * @date 2022/09/08
+ * @version 1.0.0
+ **/
+data class WebSignInRequest(
+
+    @field:NotNull
+    val employeeNumber: Int,
+
+    @field:NotBlank
+    val password: String
+)


### PR DESCRIPTION
## 작업 내용 설명
- [x] WebSignInRequest, SignInRequest
- [x] SignInUseCase
- [x] UserPersistenceAdapter를 UserJpaProvider로 분리

## 주요 변경 사항
- signIn end-point permission 설정
- signIn end-point handling
- BusinessException handling 로직

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #32 