### PR TITLE
merge: (#78) 이메일 인증 정책 설계

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ subprojects {
 
         // test
         implementation(Dependencies.SPRING_TEST)
+        testImplementation(Dependencies.MOCKITO_KOTLIN)
     }
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -42,6 +42,7 @@ object Dependencies {
 
     // test
     const val SPRING_TEST = "org.springframework.boot:spring-boot-starter-test:${PluginVersions.SPRING_BOOT_VERSION}"
+    const val MOCKITO_KOTLIN = "org.mockito.kotlin:mockito-kotlin:${PluginVersions.MOCKITO_KOTLIN_VERSION}"
 
     // s3 test
     const val S3MOCK = "io.findify:s3mock_2.12:${DependencyVersions.S3MOCK}"

--- a/buildSrc/src/main/kotlin/PluginVersions.kt
+++ b/buildSrc/src/main/kotlin/PluginVersions.kt
@@ -6,4 +6,5 @@ object PluginVersions {
     const val JPA_PLUGIN_VERSION = "1.6.21"
     const val KAPT_VERSION = "1.7.10"
     const val ALLOPEN_VERSION = "1.6.21"
+    const val MOCKITO_KOTLIN_VERSION = "4.0.0"
 }

--- a/simtong-application/src/main/kotlin/team/comit/simtong/domain/auth/spi/AuthCodeLimitPort.kt
+++ b/simtong-application/src/main/kotlin/team/comit/simtong/domain/auth/spi/AuthCodeLimitPort.kt
@@ -10,4 +10,4 @@ import team.comit.simtong.domain.user.spi.UserQueryAuthCodeLimitPort
  * @date 2022/09/18
  * @version 1.0.0
  **/
-interface AuthCodeLimitPort : UserQueryAuthCodeLimitPort
+interface AuthCodeLimitPort : UserQueryAuthCodeLimitPort, QueryAuthCodeLimitPort, CommandAuthCodeLimitPort

--- a/simtong-application/src/main/kotlin/team/comit/simtong/domain/auth/spi/AuthCodePort.kt
+++ b/simtong-application/src/main/kotlin/team/comit/simtong/domain/auth/spi/AuthCodePort.kt
@@ -1,0 +1,11 @@
+package team.comit.simtong.domain.auth.spi
+
+/**
+ *
+ * AuthCode에 관한 요청을 하는 AuthCodePort
+ *
+ * @author Chokyunghyeon
+ * @date 2022/09/25
+ * @version 1.0.0
+ **/
+interface AuthCodePort : QueryAuthCodePort, CommandAuthCodePort

--- a/simtong-application/src/main/kotlin/team/comit/simtong/domain/auth/spi/CommandAuthCodeLimitPort.kt
+++ b/simtong-application/src/main/kotlin/team/comit/simtong/domain/auth/spi/CommandAuthCodeLimitPort.kt
@@ -1,0 +1,17 @@
+package team.comit.simtong.domain.auth.spi
+
+import team.comit.simtong.domain.auth.model.AuthCodeLimit
+
+/**
+ *
+ * AuthCodeLimit의 저장을 요청하는 CommandAuthCodeLimitPort
+ *
+ * @author Chokyunghyeon
+ * @date 2022/09/24
+ * @version 1.0.0
+ **/
+interface CommandAuthCodeLimitPort {
+
+    fun save(authCodeLimit: AuthCodeLimit): AuthCodeLimit
+
+}

--- a/simtong-application/src/main/kotlin/team/comit/simtong/domain/auth/spi/CommandAuthCodePort.kt
+++ b/simtong-application/src/main/kotlin/team/comit/simtong/domain/auth/spi/CommandAuthCodePort.kt
@@ -1,0 +1,17 @@
+package team.comit.simtong.domain.auth.spi
+
+import team.comit.simtong.domain.auth.model.AuthCode
+
+/**
+ *
+ * AuthCode의 저장을 요청하는 CommandAuthCodePort
+ *
+ * @author Chokyunghyeon
+ * @date 2022/09/24
+ * @version 1.0.0
+ **/
+interface CommandAuthCodePort {
+
+    fun save(authCode: AuthCode): AuthCode
+
+}

--- a/simtong-application/src/main/kotlin/team/comit/simtong/domain/auth/usecase/CheckAuthCodeUseCase.kt
+++ b/simtong-application/src/main/kotlin/team/comit/simtong/domain/auth/usecase/CheckAuthCodeUseCase.kt
@@ -1,0 +1,27 @@
+package team.comit.simtong.domain.auth.usecase
+
+import team.comit.simtong.domain.auth.policy.CheckAuthCodePolicy
+import team.comit.simtong.domain.auth.spi.CommandAuthCodeLimitPort
+import team.comit.simtong.global.annotation.UseCase
+
+/**
+ *
+ * 이메일 인증 코드 확인을 담당하는 CheckAuthCodeUseCase
+ *
+ * @author Chokyunghyeon
+ * @date 2022/09/24
+ * @version 1.0.0
+ **/
+@UseCase
+class CheckAuthCodeUseCase(
+    private val checkAuthCodePolicy: CheckAuthCodePolicy,
+    private val commandAuthCodeLimitPort: CommandAuthCodeLimitPort
+) {
+
+    fun execute(email: String, code: String) {
+        commandAuthCodeLimitPort.save(
+            checkAuthCodePolicy.implement(email, code)
+        )
+    }
+
+}

--- a/simtong-application/src/main/kotlin/team/comit/simtong/domain/auth/usecase/SendAuthCodeUseCase.kt
+++ b/simtong-application/src/main/kotlin/team/comit/simtong/domain/auth/usecase/SendAuthCodeUseCase.kt
@@ -1,0 +1,39 @@
+package team.comit.simtong.domain.auth.usecase
+
+import team.comit.simtong.domain.auth.policy.SendAuthCodePolicy
+import team.comit.simtong.domain.auth.spi.CommandAuthCodeLimitPort
+import team.comit.simtong.domain.auth.spi.CommandAuthCodePort
+import team.comit.simtong.domain.auth.spi.SendEmailPort
+import team.comit.simtong.global.annotation.UseCase
+
+/**
+ *
+ * 이메일 인증 코드 전송을 담당하는 SendAuthCodeUseCase
+ *
+ * @author Chokyunghyeon
+ * @date 2022/09/24
+ * @version 1.0.0
+ **/
+@UseCase
+class SendAuthCodeUseCase(
+    private val sendAuthCodePolicy: SendAuthCodePolicy,
+    private val commandAuthCodeLimitPort: CommandAuthCodeLimitPort,
+    private val commandAuthCodePort: CommandAuthCodePort,
+    private val sendEmailPort: SendEmailPort
+) {
+
+    fun execute(email: String): Short {
+        val authCodeLimit = commandAuthCodeLimitPort.save(
+            sendAuthCodePolicy.restriction(email)
+        )
+
+        val authCode = commandAuthCodePort.save(
+            sendAuthCodePolicy.implement(email)
+        )
+
+        sendEmailPort.sendAuthCode(authCode.code, email)
+
+        return authCodeLimit.attemptCount
+    }
+
+}

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/auth/usecase/CheckAuthCodeUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/auth/usecase/CheckAuthCodeUseCaseTests.kt
@@ -1,0 +1,73 @@
+package team.comit.simtong.domain.auth.usecase
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.BDDMockito.given
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.auth.exception.AuthCodeNotFoundException
+import team.comit.simtong.domain.auth.model.AuthCodeLimit
+import team.comit.simtong.domain.auth.policy.CheckAuthCodePolicy
+import team.comit.simtong.domain.auth.spi.CommandAuthCodeLimitPort
+import team.comit.simtong.domain.auth.spi.QueryAuthCodePort
+
+@ExtendWith(SpringExtension::class)
+class CheckAuthCodeUseCaseTests {
+
+    @MockBean
+    private lateinit var queryAuthCodePort: QueryAuthCodePort
+
+    @MockBean
+    private lateinit var commandAuthCodeLimitPort: CommandAuthCodeLimitPort
+
+    private lateinit var checkAuthCodePolicy: CheckAuthCodePolicy
+
+    private lateinit var checkAuthCodeUseCase: CheckAuthCodeUseCase
+
+    private val email = "test@test.com"
+
+    private val code = "123456"
+
+    private val verifiedAuthCodeLimitStub: AuthCodeLimit by lazy {
+        AuthCodeLimit(
+            key = email,
+            expirationTime = AuthCodeLimit.VERIFIED_EXPIRED,
+            attemptCount = 0,
+            isVerified = true
+        )
+    }
+
+    @BeforeEach
+    fun setUp() {
+        checkAuthCodePolicy = CheckAuthCodePolicy(queryAuthCodePort)
+        checkAuthCodeUseCase = CheckAuthCodeUseCase(checkAuthCodePolicy, commandAuthCodeLimitPort)
+    }
+
+    @Test
+    fun `이메일 인증 확인 성공`() {
+        // given
+        given(queryAuthCodePort.existsAuthCodeByEmailAndCode(email, code))
+            .willReturn(true)
+
+        given(commandAuthCodeLimitPort.save(verifiedAuthCodeLimitStub))
+            .willReturn(verifiedAuthCodeLimitStub)
+
+        // when
+        checkAuthCodeUseCase.execute(email, code)
+    }
+
+    @Test
+    fun `이메일 인증 확인 실패`() {
+        // given
+        given(queryAuthCodePort.existsAuthCodeByEmailAndCode(email, code))
+            .willReturn(false)
+
+        // when & then
+        assertThrows<AuthCodeNotFoundException> {
+            checkAuthCodeUseCase.execute(email, code)
+        }
+    }
+
+}

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/auth/usecase/SendAuthCodeUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/auth/usecase/SendAuthCodeUseCaseTests.kt
@@ -1,0 +1,136 @@
+package team.comit.simtong.domain.auth.usecase
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.BDDMockito.given
+import org.mockito.BDDMockito.willDoNothing
+import org.mockito.kotlin.any
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.auth.exception.CertifiedEmailException
+import team.comit.simtong.domain.auth.exception.ExceededSendAuthCodeRequestException
+import team.comit.simtong.domain.auth.model.AuthCode
+import team.comit.simtong.domain.auth.model.AuthCodeLimit
+import team.comit.simtong.domain.auth.policy.SendAuthCodePolicy
+import team.comit.simtong.domain.auth.spi.CommandAuthCodeLimitPort
+import team.comit.simtong.domain.auth.spi.CommandAuthCodePort
+import team.comit.simtong.domain.auth.spi.QueryAuthCodeLimitPort
+import team.comit.simtong.domain.auth.spi.SendEmailPort
+
+@ExtendWith(SpringExtension::class)
+class SendAuthCodeUseCaseTests {
+
+    @MockBean
+    private lateinit var queryAuthCodeLimitPort: QueryAuthCodeLimitPort
+
+    @MockBean
+    private lateinit var commandAuthCodeLimitPort: CommandAuthCodeLimitPort
+
+    @MockBean
+    private lateinit var commandAuthCodePort: CommandAuthCodePort
+
+    @MockBean
+    private lateinit var sendEmailPort: SendEmailPort
+
+    private lateinit var sendAuthCodePolicy: SendAuthCodePolicy
+
+    private lateinit var sendAuthCodeUseCase: SendAuthCodeUseCase
+
+    private val email = "test@test.com"
+
+    private val code = "123456"
+
+    private val authCodeLimitStub by lazy {
+        AuthCodeLimit(
+            key = email,
+            expirationTime = AuthCodeLimit.EXPIRED,
+            attemptCount = 1,
+            isVerified = false
+        )
+    }
+
+    private val verifiedAuthCodeLimitStub by lazy {
+        AuthCodeLimit(
+            key = email,
+            expirationTime = AuthCodeLimit.EXPIRED,
+            attemptCount = 1,
+            isVerified = true
+        )
+    }
+
+    private val exceedAuthCodeLimitStub by lazy {
+        AuthCodeLimit(
+            key = email,
+            expirationTime = AuthCodeLimit.EXPIRED,
+            attemptCount = AuthCodeLimit.MAX_ATTEMPT_COUNT,
+            isVerified = false
+        )
+    }
+
+    private val authCodeStub by lazy {
+        AuthCode(
+            key = email,
+            code = code,
+            expirationTime = AuthCode.EXPIRED
+        )
+    }
+
+    @BeforeEach
+    fun setUp() {
+        sendAuthCodePolicy = SendAuthCodePolicy(queryAuthCodeLimitPort)
+        sendAuthCodeUseCase = SendAuthCodeUseCase(
+            sendAuthCodePolicy,
+            commandAuthCodeLimitPort,
+            commandAuthCodePort,
+            sendEmailPort
+        )
+    }
+
+    @Test
+    fun `이메일 인증 코드 발송`() {
+        // given
+        given(queryAuthCodeLimitPort.queryAuthCodeLimitByEmail(email))
+            .willReturn(null)
+
+        given(commandAuthCodeLimitPort.save(any()))
+            .willReturn(authCodeLimitStub)
+
+        given(commandAuthCodePort.save(any()))
+            .willReturn(authCodeStub)
+
+        willDoNothing().given(sendEmailPort).sendAuthCode(code, email)
+
+        // when
+        val result = sendAuthCodeUseCase.execute(email)
+
+        // then
+        assertEquals(result, 1)
+    }
+
+    @Test
+    fun `이미 인증된 이메일`() {
+        // given
+        given(queryAuthCodeLimitPort.queryAuthCodeLimitByEmail(email))
+            .willReturn(verifiedAuthCodeLimitStub)
+
+        // when & then
+        assertThrows<CertifiedEmailException> {
+            sendAuthCodeUseCase.execute(email)
+        }
+    }
+
+    @Test
+    fun `이메일 인증 코드 전송 횟수 초과`() {
+        // given
+        given(queryAuthCodeLimitPort.queryAuthCodeLimitByEmail(email))
+            .willReturn(exceedAuthCodeLimitStub)
+
+        assertThrows<ExceededSendAuthCodeRequestException> {
+            sendAuthCodeUseCase.execute(email)
+        }
+    }
+
+}

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/error/AuthErrorCode.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/error/AuthErrorCode.kt
@@ -16,11 +16,16 @@ enum class AuthErrorCode(
 ): ErrorProperty {
 
     // 401
+    AUTHCODE_NOT_FOUND(401, "인증 코드를 찾을 수 없음"),
     UNCERTIFIED_EMAIL(401, "인증되지 않은 이메일"),
     REFRESH_TOKEN_NOT_FOUND(401, "토큰을 찾을 수 없음"),
 
     // 409
-    ALREADY_USED_EMAIL(409, "이미 사용된 이메일");
+    ALREADY_USED_EMAIL(409, "이미 사용된 이메일"),
+    ALREADY_CERTIFIED_EMAIL(409, "이미 인증된 이메일"),
+
+    // 429
+    EXCEEDED_SEND_AUTHCODE_REQUEST(429, "인증 코드 발송 횟수 초과");
 
     override fun message(): String = message
     override fun status(): Int = status

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/exception/AuthCodeNotFoundException.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/exception/AuthCodeNotFoundException.kt
@@ -1,0 +1,21 @@
+package team.comit.simtong.domain.auth.exception
+
+import team.comit.simtong.domain.auth.error.AuthErrorCode
+import team.comit.simtong.global.error.BusinessException
+
+/**
+ *
+ * AuthCode Not Found Error를 발생시키는 AuthCodeNotFoundException
+ *
+ * @author Chokyunghyeon
+ * @date 2022/09/25
+ * @version 1.0.0
+ **/
+class AuthCodeNotFoundException private constructor(): BusinessException(AuthErrorCode.AUTHCODE_NOT_FOUND) {
+
+    companion object {
+        @JvmField
+        val EXCEPTION = AuthCodeNotFoundException()
+    }
+
+}

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/exception/CertifiedEmailException.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/exception/CertifiedEmailException.kt
@@ -1,0 +1,21 @@
+package team.comit.simtong.domain.auth.exception
+
+import team.comit.simtong.domain.auth.error.AuthErrorCode
+import team.comit.simtong.global.error.BusinessException
+
+/**
+ *
+ * Already Certified Email Error를 발생시키는 CertifiedEmailException
+ *
+ * @author Chokyunghyeon
+ * @date 2022/09/24
+ * @version 1.0.0
+ **/
+class CertifiedEmailException private constructor(): BusinessException(AuthErrorCode.ALREADY_CERTIFIED_EMAIL) {
+
+    companion object {
+        @JvmField
+        val EXCEPTION = CertifiedEmailException()
+    }
+
+}

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/exception/ExceededSendAuthCodeRequestException.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/exception/ExceededSendAuthCodeRequestException.kt
@@ -1,0 +1,21 @@
+package team.comit.simtong.domain.auth.exception
+
+import team.comit.simtong.domain.auth.error.AuthErrorCode
+import team.comit.simtong.global.error.BusinessException
+
+/**
+ *
+ * Exceeded Send AuthCode Request Error를 발생시키는 ExceededSendAuthCodeRequestException
+ *
+ * @author Chokyunghyeon
+ * @date 2022/09/24
+ * @version 1.0.0
+ **/
+class ExceededSendAuthCodeRequestException private constructor(): BusinessException(AuthErrorCode.EXCEEDED_SEND_AUTHCODE_REQUEST) {
+
+    companion object {
+        @JvmField
+        val EXCEPTION = ExceededSendAuthCodeRequestException()
+    }
+
+}

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/model/AuthCode.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/model/AuthCode.kt
@@ -1,0 +1,26 @@
+package team.comit.simtong.domain.auth.model
+
+import team.comit.simtong.global.annotation.Aggregate
+
+/**
+ *
+ * AuthCodeAggregate Root를 담당하는 AuthCode
+ *
+ * @author Chokyunghyeon
+ * @date 2022/09/24
+ * @version 1.0.0
+ **/
+@Aggregate
+class AuthCode(
+    val key: String,
+
+    val code: String,
+
+    val expirationTime: Int
+) {
+
+    companion object {
+        const val EXPIRED = 180
+    }
+
+}

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/model/AuthCodeLimit.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/model/AuthCodeLimit.kt
@@ -4,7 +4,7 @@ import team.comit.simtong.global.annotation.Aggregate
 
 /**
  *
- * AuthCodeLimit Aggregate Root를 담당하는 AuthCodeLimit
+ * AuthCodeLimitAggregate Root를 담당하는 AuthCodeLimit
  *
  * @author Chokyunghyeon
  * @author kimbeomjin
@@ -20,4 +20,21 @@ class AuthCodeLimit(
     val attemptCount: Short,
 
     val isVerified: Boolean
-)
+) {
+
+    companion object {
+        const val EXPIRED = 1800
+        const val MAX_ATTEMPT_COUNT = 5
+        const val VERIFIED_EXPIRED = 2700
+    }
+
+    fun sendAuthCode(): AuthCodeLimit {
+        return AuthCodeLimit(
+            key = key,
+            expirationTime = expirationTime,
+            attemptCount = attemptCount.inc(),
+            isVerified = false
+        )
+    }
+
+}

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/model/AuthCodeLimit.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/model/AuthCodeLimit.kt
@@ -24,7 +24,7 @@ class AuthCodeLimit(
 
     companion object {
         const val EXPIRED = 1800
-        const val MAX_ATTEMPT_COUNT = 5
+        const val MAX_ATTEMPT_COUNT: Short = 5
         const val VERIFIED_EXPIRED = 2700
     }
 

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/policy/CheckAuthCodePolicy.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/policy/CheckAuthCodePolicy.kt
@@ -1,0 +1,34 @@
+package team.comit.simtong.domain.auth.policy
+
+import team.comit.simtong.domain.auth.exception.AuthCodeNotFoundException
+import team.comit.simtong.domain.auth.model.AuthCodeLimit
+import team.comit.simtong.domain.auth.spi.QueryAuthCodePort
+import team.comit.simtong.global.annotation.Policy
+
+/**
+ *
+ * 이메일 인증 코드 확인 정책을 관리하는 CheckAuthCodePolicy
+ *
+ * @author Chokyunghyeon
+ * @date 2022/09/25
+ * @version 1.0.0
+ **/
+@Policy
+class CheckAuthCodePolicy(
+    private val queryAuthCodePort: QueryAuthCodePort
+) {
+
+    fun implement(email: String, code: String): AuthCodeLimit {
+        if (!queryAuthCodePort.existsAuthCodeByEmailAndCode(email, code)) {
+            throw AuthCodeNotFoundException.EXCEPTION
+        }
+
+        return AuthCodeLimit(
+            key = email,
+            expirationTime = AuthCodeLimit.VERIFIED_EXPIRED,
+            attemptCount = 0,
+            isVerified = true
+        )
+    }
+
+}

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/policy/SendAuthCodePolicy.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/policy/SendAuthCodePolicy.kt
@@ -1,0 +1,52 @@
+package team.comit.simtong.domain.auth.policy
+
+import net.bytebuddy.utility.RandomString
+import team.comit.simtong.domain.auth.exception.CertifiedEmailException
+import team.comit.simtong.domain.auth.exception.ExceededSendAuthCodeRequestException
+import team.comit.simtong.domain.auth.model.AuthCode
+import team.comit.simtong.domain.auth.model.AuthCodeLimit
+import team.comit.simtong.domain.auth.spi.QueryAuthCodeLimitPort
+import team.comit.simtong.global.annotation.Policy
+
+/**
+ *
+ * 이메일 인증 정책을 관리하는 SendAuthCodeLimitPolicy
+ *
+ * @author Chokyunghyeon
+ * @date 2022/09/24
+ * @version 1.0.0
+ **/
+@Policy
+class SendAuthCodePolicy(
+    private val queryAuthCodeLimitPort: QueryAuthCodeLimitPort
+) {
+
+    fun restriction(email: String): AuthCodeLimit {
+        val authCodeLimit = queryAuthCodeLimitPort.queryAuthCodeLimitByEmail(email)
+            ?: AuthCodeLimit(
+                key = email,
+                expirationTime = AuthCodeLimit.EXPIRED,
+                attemptCount = 0,
+                isVerified = false
+            )
+
+        if(authCodeLimit.isVerified) {
+            throw CertifiedEmailException.EXCEPTION
+        }
+
+        if (authCodeLimit.attemptCount <= AuthCodeLimit.MAX_ATTEMPT_COUNT) {
+            throw ExceededSendAuthCodeRequestException.EXCEPTION
+        }
+
+        return authCodeLimit.sendAuthCode()
+    }
+
+    fun implement(email: String): AuthCode {
+        return AuthCode(
+            key = email,
+            code = RandomString(6).nextString(),
+            expirationTime = AuthCode.EXPIRED
+        )
+    }
+
+}

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/policy/SendAuthCodePolicy.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/policy/SendAuthCodePolicy.kt
@@ -34,7 +34,7 @@ class SendAuthCodePolicy(
             throw CertifiedEmailException.EXCEPTION
         }
 
-        if (authCodeLimit.attemptCount <= AuthCodeLimit.MAX_ATTEMPT_COUNT) {
+        if (authCodeLimit.attemptCount >= AuthCodeLimit.MAX_ATTEMPT_COUNT) {
             throw ExceededSendAuthCodeRequestException.EXCEPTION
         }
 

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/spi/QueryAuthCodeLimitPort.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/spi/QueryAuthCodeLimitPort.kt
@@ -1,0 +1,17 @@
+package team.comit.simtong.domain.auth.spi
+
+import team.comit.simtong.domain.auth.model.AuthCodeLimit
+
+/**
+ *
+ * AuthCodeLimit에 관한 Query를 요청하는 QueryAuthCodeLimitPort
+ *
+ * @author Chokyunghyeon
+ * @date 2022/09/24
+ * @version 1.0.0
+ **/
+interface QueryAuthCodeLimitPort {
+
+    fun queryAuthCodeLimitByEmail(email: String): AuthCodeLimit?
+
+}

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/spi/QueryAuthCodePort.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/spi/QueryAuthCodePort.kt
@@ -1,0 +1,15 @@
+package team.comit.simtong.domain.auth.spi
+
+/**
+ *
+ * AuthCode에 관한 Query를 요청하는 QueryAuthCodePort
+ *
+ * @author Chokyunghyeon
+ * @date 2022/09/25
+ * @version 1.0.0
+ **/
+interface QueryAuthCodePort {
+
+    fun existsAuthCodeByEmailAndCode(email: String, code: String): Boolean
+
+}

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/user/spi/UserSecurityPort.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/user/spi/UserSecurityPort.kt
@@ -2,7 +2,7 @@ package team.comit.simtong.domain.user.spi
 
 /**
  *
- * User와 관한 보안 처리를 요청하는 UserSecurityPort
+ * User에 관한 보안 처리를 요청하는 UserSecurityPort
  *
  * @author Chokyunghyeon
  * @author kimbeomjin

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/global/error/WebErrorHandler.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/global/error/WebErrorHandler.kt
@@ -92,6 +92,7 @@ class WebErrorHandler {
 
     /**
      * Http Message를 읽지 못하는 경우 발생
+     * 주로 객체를 JSON 형태로 받지 못하는 경우 발생
      */
     @ExceptionHandler(HttpMessageNotReadableException::class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
@@ -101,5 +102,12 @@ class WebErrorHandler {
         return ErrorResponse.of(GlobalErrorCode.BAD_REQUEST)
     }
 
-
+    /**
+     * 전송받은 Request 의 Non-Null 필드가 Null 일 때 발생
+     */
+    @ExceptionHandler(NullPointerException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    protected fun handleNestedServletException(exception: NullPointerException): ErrorResponse? {
+        return ErrorResponse.of(GlobalErrorCode.BAD_REQUEST)
+    }
 }

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/global/security/SecurityConfig.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/global/security/SecurityConfig.kt
@@ -49,6 +49,10 @@ class SecurityConfig(
             .antMatchers(HttpMethod.GET, "/commons/employee-number").permitAll()
             .antMatchers(HttpMethod.PUT, "/commons/token/reissue").permitAll()
 
+            // emails
+            .antMatchers(HttpMethod.HEAD, "/emails").permitAll()
+            .antMatchers(HttpMethod.POST, "/emails/code").permitAll()
+
             .anyRequest().authenticated()
 
         http

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/auth/AuthCodeLimitPersistenceAdapter.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/auth/AuthCodeLimitPersistenceAdapter.kt
@@ -1,6 +1,7 @@
 package team.comit.simtong.persistence.auth
 
 import org.springframework.stereotype.Component
+import team.comit.simtong.domain.auth.model.AuthCodeLimit
 import team.comit.simtong.domain.auth.spi.AuthCodeLimitPort
 import team.comit.simtong.persistence.auth.mapper.AuthCodeLimitMapper
 import team.comit.simtong.persistence.auth.repository.AuthCodeLimitRepository
@@ -23,5 +24,11 @@ class AuthCodeLimitPersistenceAdapter(
     override fun queryAuthCodeLimitByEmail(email: String) = authCodeLimitMapper.toDomain(
         authCodeLimitRepository.queryAuthCodeLimitEntityByKey(email)
     )
+
+    override fun save(authCodeLimit: AuthCodeLimit) = authCodeLimitMapper.toDomain(
+       authCodeLimitRepository.save(
+           authCodeLimitMapper.toEntity(authCodeLimit)
+       )
+    )!!
 
 }

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/auth/AuthCodePersistenceAdapter.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/auth/AuthCodePersistenceAdapter.kt
@@ -1,0 +1,32 @@
+package team.comit.simtong.persistence.auth
+
+import org.springframework.stereotype.Component
+import team.comit.simtong.domain.auth.model.AuthCode
+import team.comit.simtong.domain.auth.spi.AuthCodePort
+import team.comit.simtong.persistence.auth.mapper.AuthCodeMapper
+import team.comit.simtong.persistence.auth.repository.AuthCodeRepository
+
+/**
+ *
+ * AuthCode를 관리하는 AuthCodePersistenceAdapter
+ *
+ * @author Chokyunghyeon
+ * @date 2022/09/25
+ * @version 1.0.0
+ **/
+@Component
+class AuthCodePersistenceAdapter(
+    private val authCodeMapper: AuthCodeMapper,
+    private val authCodeRepository: AuthCodeRepository
+): AuthCodePort {
+
+    override fun existsAuthCodeByEmailAndCode(email: String, code: String) =
+        authCodeRepository.existsAuthCodeEntityByKeyAndCode(email, code)
+
+    override fun save(authCode: AuthCode) = authCodeMapper.toDomain(
+        authCodeRepository.save(
+            authCodeMapper.toEntity(authCode)
+        )
+    )!!
+
+}

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/auth/entity/AuthCodeEntity.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/auth/entity/AuthCodeEntity.kt
@@ -4,6 +4,7 @@ import org.hibernate.validator.constraints.Length
 import org.springframework.data.annotation.Id
 import org.springframework.data.redis.core.RedisHash
 import org.springframework.data.redis.core.TimeToLive
+import org.springframework.data.redis.core.index.Indexed
 import javax.validation.constraints.NotNull
 
 /**
@@ -22,6 +23,7 @@ class AuthCodeEntity(
 
     @field:NotNull
     @field:Length(max = 6)
+    @Indexed
     val code: String,
 
     @field:NotNull

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/auth/entity/AuthCodeLimitEntity.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/auth/entity/AuthCodeLimitEntity.kt
@@ -26,9 +26,9 @@ class AuthCodeLimitEntity(
 
     @field:NotNull
     @ColumnDefault("1")
-    val attemptCount: Short = 1,
+    val attemptCount: Short,
 
     @field:NotNull
     @ColumnDefault("false")
-    val isVerified: Boolean = false
+    val isVerified: Boolean
 )

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/auth/entity/AuthCodeLimitEntity.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/auth/entity/AuthCodeLimitEntity.kt
@@ -22,13 +22,13 @@ class AuthCodeLimitEntity(
 
     @field:NotNull
     @TimeToLive
-    val expirationTime: Int
-) {
+    val expirationTime: Int,
+
     @field:NotNull
     @ColumnDefault("1")
-    val attemptCount: Short = 1
+    val attemptCount: Short = 1,
 
     @field:NotNull
     @ColumnDefault("false")
     val isVerified: Boolean = false
-}
+)

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/auth/mapper/AuthCodeMapper.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/auth/mapper/AuthCodeMapper.kt
@@ -1,0 +1,18 @@
+package team.comit.simtong.persistence.auth.mapper
+
+import org.mapstruct.Mapper
+import team.comit.simtong.domain.auth.model.AuthCode
+import team.comit.simtong.persistence.GenericMapper
+import team.comit.simtong.persistence.auth.entity.AuthCodeEntity
+
+/**
+ *
+ * AuthCodeEntity와 DomainAuthCode를 변환하는 AuthCodeMapper
+ *
+ * @author Chokyunghyeon
+ * @date 2022/09/25
+ * @version 1.0.0
+ **/
+@Mapper
+abstract class AuthCodeMapper : GenericMapper<AuthCodeEntity, AuthCode> {
+}

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/auth/repository/AuthCodeRepository.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/auth/repository/AuthCodeRepository.kt
@@ -14,4 +14,7 @@ import team.comit.simtong.persistence.auth.entity.AuthCodeEntity
  **/
 @Repository
 interface AuthCodeRepository : CrudRepository<AuthCodeEntity, String> {
+
+    fun existsAuthCodeEntityByKeyAndCode(key: String, code: String): Boolean
+
 }

--- a/simtong-presentation/src/main/kotlin/team/comit/simtong/email/WebEmailAdapter.kt
+++ b/simtong-presentation/src/main/kotlin/team/comit/simtong/email/WebEmailAdapter.kt
@@ -1,0 +1,42 @@
+package team.comit.simtong.email
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import team.comit.simtong.domain.auth.usecase.CheckAuthCodeUseCase
+import team.comit.simtong.domain.auth.usecase.SendAuthCodeUseCase
+import team.comit.simtong.email.dto.request.WebCheckAuthCodeRequest
+import team.comit.simtong.email.dto.request.WebSendAuthCodeRequest
+import team.comit.simtong.email.dto.response.WebRemainChanceResponse
+import javax.validation.Valid
+
+/**
+ *
+ * 이메일에 관한 요청을 받는 WebEmailAdapter
+ *
+ * @author Chokyunghyeon
+ * @date 2022/09/24
+ * @version 1.0.0
+ **/
+@RestController
+@RequestMapping("/emails")
+class WebEmailAdapter(
+    private val sendAuthCodeUseCase: SendAuthCodeUseCase,
+    private val checkAuthCodeUseCase: CheckAuthCodeUseCase
+) {
+
+    @PostMapping("/code")
+    fun sendAuthCode(@Valid @RequestBody request: WebSendAuthCodeRequest): WebRemainChanceResponse {
+        return WebRemainChanceResponse(
+            sendAuthCodeUseCase.execute(request.email)
+        )
+    }
+
+    @GetMapping
+    fun checkAuthCode(@Valid request: WebCheckAuthCodeRequest) {
+        checkAuthCodeUseCase.execute(request.email, request.code)
+    }
+
+}

--- a/simtong-presentation/src/main/kotlin/team/comit/simtong/email/dto/request/WebCheckAuthCodeRequest.kt
+++ b/simtong-presentation/src/main/kotlin/team/comit/simtong/email/dto/request/WebCheckAuthCodeRequest.kt
@@ -1,0 +1,23 @@
+package team.comit.simtong.email.dto.request
+
+import org.hibernate.validator.constraints.Length
+import javax.validation.constraints.Email
+import javax.validation.constraints.NotBlank
+
+/**
+ *
+ * 이메일 인증 코드 확인을 요청하는 WebCheckAuthCodeRequest
+ *
+ * @author Chokyunghyeon
+ * @date 2022/09/24
+ * @version 1.0.0
+ **/
+data class WebCheckAuthCodeRequest(
+    @field:NotBlank
+    @field:Email
+    val email: String,
+
+    @field:NotBlank
+    @field:Length(min = 6, max = 6)
+    val code: String
+)

--- a/simtong-presentation/src/main/kotlin/team/comit/simtong/email/dto/request/WebSendAuthCodeRequest.kt
+++ b/simtong-presentation/src/main/kotlin/team/comit/simtong/email/dto/request/WebSendAuthCodeRequest.kt
@@ -1,0 +1,18 @@
+package team.comit.simtong.email.dto.request
+
+import javax.validation.constraints.Email
+import javax.validation.constraints.NotBlank
+
+/**
+ *
+ * 이메일 인증 코드 전송을 요청하는 WebSendEmailRequest
+ *
+ * @author Chokyunghyeon
+ * @date 2022/09/24
+ * @version 1.0.0
+ **/
+data class WebSendAuthCodeRequest(
+    @field:NotBlank
+    @field:Email
+    val email: String
+)

--- a/simtong-presentation/src/main/kotlin/team/comit/simtong/email/dto/response/WebRemainChanceResponse.kt
+++ b/simtong-presentation/src/main/kotlin/team/comit/simtong/email/dto/response/WebRemainChanceResponse.kt
@@ -1,0 +1,13 @@
+package team.comit.simtong.email.dto.response
+
+/**
+ *
+ * 이메일 인증 코드의 남은 발송 횟수를 전송하는 WebRemainChanceResponse
+ *
+ * @author Chokyunghyeon
+ * @date 2022/09/24
+ * @version 1.0.0
+ **/
+data class WebRemainChanceResponse(
+    val remainChance: Short
+)


### PR DESCRIPTION
## 작업 내용 설명
- [x] AuthCode Domain Model 설계
- [x] AuthCode & AuthCodeLimit 영속성 관리 설계
- [x] 이메일 인증 API 구현
- [x] 이메일 인증 예외 처리
- [x] 이메일 인증 Port 설계

## 주요 변경 사항
- UserSecurityPort javadoc 오타 수정
- AuthCodeEntity code 필드 @Indexed 추가
- AuthCodeLimitEntity 생성자 수정
- mockito-kotlin 의존성 추가

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #78 