### PR TITLE
merge: (#147) Domain Properties 에러

### DIFF
--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/DomainPropertiesInitialization.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/DomainPropertiesInitialization.kt
@@ -1,0 +1,22 @@
+package team.comit.simtong.domain
+
+import team.comit.simtong.global.DomainProperties
+import team.comit.simtong.global.DomainPropertiesPrefix
+
+/**
+ * 가장 처음 테스트되는 클래스에 Import
+ * Domain Properties 초기화
+ */
+class DomainPropertiesInitialization {
+    init {
+        DomainProperties.putAll(
+            mapOf(
+                Pair(DomainPropertiesPrefix.USER_DEFAULT_IMAGE, "test"),
+                Pair(DomainPropertiesPrefix.AUTHCODE_EXPIRED, "12345"),
+                Pair(DomainPropertiesPrefix.AUTHCODELIMIT_EXPIRED, "12345"),
+                Pair(DomainPropertiesPrefix.AUTHCODELIMIT_VERIFIED_EXPIRED, "12345"),
+                Pair(DomainPropertiesPrefix.AUTHCODELIMIT_MAX_ATTEMPT_COUNT, "12345")
+            )
+        )
+    }
+}

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/auth/usecase/CheckAuthCodeUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/auth/usecase/CheckAuthCodeUseCaseTests.kt
@@ -7,12 +7,15 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.auth.exception.AuthCodeMismatchException
 import team.comit.simtong.domain.auth.model.AuthCode
 import team.comit.simtong.domain.auth.spi.CommandAuthCodeLimitPort
 import team.comit.simtong.domain.auth.spi.QueryAuthCodePort
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class CheckAuthCodeUseCaseTests {
 

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/model/AuthCode.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/model/AuthCode.kt
@@ -1,7 +1,7 @@
 package team.comit.simtong.domain.auth.model
 
 import net.bytebuddy.utility.RandomString
-import team.comit.simtong.global.DomainProperties.Companion.getProperty
+import team.comit.simtong.global.DomainProperties.getProperty
 import team.comit.simtong.global.DomainPropertiesPrefix
 import team.comit.simtong.global.annotation.Aggregate
 import team.comit.simtong.global.annotation.Default

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/model/AuthCodeLimit.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/auth/model/AuthCodeLimit.kt
@@ -1,7 +1,7 @@
 package team.comit.simtong.domain.auth.model
 
 import team.comit.simtong.domain.auth.exception.ExceededSendAuthCodeRequestException
-import team.comit.simtong.global.DomainProperties.Companion.getProperty
+import team.comit.simtong.global.DomainProperties.getProperty
 import team.comit.simtong.global.DomainPropertiesPrefix
 import team.comit.simtong.global.annotation.Aggregate
 import team.comit.simtong.global.annotation.Default

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/user/model/User.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/user/model/User.kt
@@ -1,6 +1,6 @@
 package team.comit.simtong.domain.user.model
 
-import team.comit.simtong.global.DomainProperties.Companion.getProperty
+import team.comit.simtong.global.DomainProperties.getProperty
 import team.comit.simtong.global.DomainPropertiesPrefix
 import team.comit.simtong.global.annotation.Aggregate
 import java.util.UUID

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/global/DomainProperties.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/global/DomainProperties.kt
@@ -1,5 +1,6 @@
 package team.comit.simtong.global
 
+import team.comit.simtong.global.exception.NotInitializationPropertiesException
 import java.util.Properties
 
 /**
@@ -13,7 +14,7 @@ import java.util.Properties
 object DomainProperties : Properties() {
 
     override fun getProperty(key: String): String {
-        return super.getProperty(key) ?: throw InternalError("### Missing Domain Properties '$key'")
+        return super.getProperty(key) ?: throw NotInitializationPropertiesException
     }
 
 }

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/global/DomainProperties.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/global/DomainProperties.kt
@@ -1,7 +1,5 @@
 package team.comit.simtong.global
 
-import java.lang.ClassLoader.getSystemResourceAsStream
-import java.lang.System.getenv
 import java.util.Properties
 
 /**
@@ -12,36 +10,10 @@ import java.util.Properties
  * @date 2022/10/29
  * @version 1.0.0
  **/
-internal class DomainProperties {
+object DomainProperties : Properties() {
 
-    /**
-     * Properties 동작 과정
-     *
-     * properties file을 읽어 Properties 객체로 변환
-     *
-     * 만약, value가 환경변수라면
-     * value의 환경변수를 불러와 Properties 저장
-     */
-    companion object {
-        @JvmField
-        val properties = Properties().also { properties ->
-            properties.load(getSystemResourceAsStream(DomainPropertiesPrefix.PROPERTIES_FILE))
-            properties.forEach { entry ->
-                (entry.value as String).let { str ->
-                    if (str.startsWith('$')) {
-                        str.replace(Regex("[$}{]"), "").split(':').let {
-                            when (it.size) {
-                                1 -> properties[entry.key] = getenv(it[0])
-                                    ?: throw InternalError("Missing Environment Variable [${DomainPropertiesPrefix.PROPERTIES_FILE}] '${entry.key}'")
-                                2 -> properties[entry.key] = getenv(it[0]) ?: it[1]
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        fun getProperty(key: String): String = properties.getProperty(key)
+    override fun getProperty(key: String): String {
+        return super.getProperty(key) ?: throw InternalError("### Missing Domain Properties '$key'")
     }
 
 }

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/global/DomainProperties.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/global/DomainProperties.kt
@@ -14,7 +14,7 @@ import java.util.Properties
 object DomainProperties : Properties() {
 
     override fun getProperty(key: String): String {
-        return super.getProperty(key) ?: throw NotInitializationPropertiesException
+        return super.getProperty(key) ?: throw NotInitializationPropertiesException.EXCEPTION
     }
 
 }

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/global/DomainPropertiesPrefix.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/global/DomainPropertiesPrefix.kt
@@ -2,7 +2,7 @@ package team.comit.simtong.global
 
 /**
  *
- * Domain Properties의 경로를 관리하는 DomainPropertiesPrefix
+ * Domain Properties의 Key를 관리하는 DomainPropertiesPrefix
  *
  * @author Chokyunghyeon
  * @date 2022/10/29
@@ -10,18 +10,15 @@ package team.comit.simtong.global
  **/
 object DomainPropertiesPrefix {
 
-    // properties file
-    const val PROPERTIES_FILE = "domain.properties"
-
     // User
-    const val USER_DEFAULT_IMAGE = "domain.user.default-image"
+    const val USER_DEFAULT_IMAGE = "user.default-image"
 
     // AuthCode
-    const val AUTHCODE_EXPIRED = "domain.authcode.expired"
+    const val AUTHCODE_EXPIRED = "authcode.expired"
 
     // AuthCodeLimit
-    const val AUTHCODELIMIT_EXPIRED = "domain.authcodelimit.expired"
-    const val AUTHCODELIMIT_VERIFIED_EXPIRED = "domain.authcodelimit.verified-expired"
-    const val AUTHCODELIMIT_MAX_ATTEMPT_COUNT = "domain.authcodelimit.max-attempt-count"
+    const val AUTHCODELIMIT_EXPIRED = "authcodelimit.expired"
+    const val AUTHCODELIMIT_VERIFIED_EXPIRED = "authcodelimit.verified-expired"
+    const val AUTHCODELIMIT_MAX_ATTEMPT_COUNT = "authcodelimit.max-attempt-count"
 
 }

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/global/error/DomainErrorCode.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/global/error/DomainErrorCode.kt
@@ -1,0 +1,21 @@
+package team.comit.simtong.global.error
+
+/**
+ *
+ * Domain에서 발생하는 ErrorCode를 관리하는 DomainErrorCode
+ *
+ * @author Chokyunghyeon
+ * @date 2022/11/26
+ * @version 1.0.0
+ **/
+enum class DomainErrorCode(
+    private val status: Int,
+    private val message: String
+) : ErrorProperty {
+
+    NOT_INITIALIZATION_PROPERTIES(500, "Domain Properties 초기화 실패");
+
+    override fun message() = message
+
+    override fun status() = status
+}

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/global/exception/NotInitializationPropertiesException.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/global/exception/NotInitializationPropertiesException.kt
@@ -1,0 +1,14 @@
+package team.comit.simtong.global.exception
+
+import team.comit.simtong.global.error.BusinessException
+import team.comit.simtong.global.error.DomainErrorCode
+
+/**
+ *
+ * Domain Properties 초기화 에러를 발생시키는 NotInitializationPropertiesException
+ *
+ * @author Chokyunghyeon
+ * @date 2022/11/26
+ * @version 1.0.0
+ **/
+object NotInitializationPropertiesException : BusinessException(DomainErrorCode.NOT_INITIALIZATION_PROPERTIES)

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/global/exception/NotInitializationPropertiesException.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/global/exception/NotInitializationPropertiesException.kt
@@ -11,4 +11,11 @@ import team.comit.simtong.global.error.DomainErrorCode
  * @date 2022/11/26
  * @version 1.0.0
  **/
-object NotInitializationPropertiesException : BusinessException(DomainErrorCode.NOT_INITIALIZATION_PROPERTIES)
+class NotInitializationPropertiesException private constructor() : BusinessException(DomainErrorCode.NOT_INITIALIZATION_PROPERTIES) {
+
+    companion object {
+        @JvmField
+        val EXCEPTION = NotInitializationPropertiesException()
+    }
+
+}

--- a/simtong-domain/src/main/resources/domain.properties
+++ b/simtong-domain/src/main/resources/domain.properties
@@ -1,5 +1,0 @@
-domain.user.default-image=${USER_DEFAULT_IMAGE:}
-domain.authcode.expired=${AUTHCODE_EXPIRED:1234567890}
-domain.authcodelimit.expired=${AUTHCODELIMIT_EXPIRED:1234567890}
-domain.authcodelimit.verified-expired=${AUTHCODELIMIT_VERIFIED_EXPIRED:1234567890}
-domain.authcodelimit.max-attempt-count=${AUTHCODELIMIT_MAX_ATTEMPT_COUNT:12345}

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/global/config/DomainPropertiesConfig.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/global/config/DomainPropertiesConfig.kt
@@ -17,6 +17,10 @@ import team.comit.simtong.global.DomainProperties
 class DomainPropertiesConfig(
     model: Map<String, String>
 ) {
+
+    /**
+     * Domain 설정 변수를 Domain Properties에 매핑
+     */
     init {
         DomainProperties.putAll(model)
     }

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/global/config/DomainPropertiesConfig.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/global/config/DomainPropertiesConfig.kt
@@ -1,0 +1,23 @@
+package team.comit.simtong.global.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+import team.comit.simtong.global.DomainProperties
+
+/**
+ *
+ * Domain Aggregate의 설정을 불러오는 DomainConfig
+ *
+ * @author Chokyunghyeon
+ * @date 2022/11/25
+ * @version 1.0.0
+ **/
+@ConstructorBinding
+@ConfigurationProperties("domain")
+class DomainPropertiesConfig(
+    model: Map<String, String>
+) {
+    init {
+        DomainProperties.putAll(model)
+    }
+}

--- a/simtong-infrastructure/src/main/resources/application.yml
+++ b/simtong-infrastructure/src/main/resources/application.yml
@@ -14,6 +14,19 @@ spring:
     access-exp: ${ACCESS_EXP:180}
     refresh-exp: ${REFRESH_EXP:180}
 
+
+domain:
+  model:
+    user:
+      default-image: ${USER_DEFAULT_IMAGE:TODO}
+    authcode:
+      expired: ${AUTHCODE_EXPIRED:1234567890}
+    authcodelimit:
+      expired: ${AUTHCODELIMIT_EXPIRED:1234567890}
+      verified-expired: ${AUTHCODELIMIT_VERIFIED_EXPIRED:1234567890}
+      max-attempt-count: ${AUTHCODELIMIT_MAX_ATTEMPT_COUNT:12345}
+
+
 logging:
   level:
     com:


### PR DESCRIPTION
## 작업 내용 설명
- **기존 방식** : Domain Aggregate 객체 초기화 접근시 
Domain resources의 `domain.properties`를 읽어 Domain Aggregate 변수 초기화

- **문제점** : 배포 환경에서 Docker Image 실행 후 Domain Aggregate 초기화 접근시 `domain.properties`를 읽을 수 없는 문제 확인

- **해결 조건** : 환경변수 적용 가능, 외부 의존성 사용 불가, 개발 환경 영향 없음

- **해결방식** : Infra에서 ConfigurationProperties 사용, Map으로 변수 바인딩 → DomainProperties 초기화

## 주요 변경 사항
- DomainProperties 파일 읽기 로직 삭제
- Domain의 domain.properties 파일 제거 → application.yml 파일로 property 이동
- DomainProperties test 초기화 에러 회피

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #147