### PR TITLE
merge: (#158) Domain Properties 초기화 전체 적용

### DIFF
--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/DomainPropertiesInitialization.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/DomainPropertiesInitialization.kt
@@ -3,11 +3,7 @@ package team.comit.simtong.domain
 import team.comit.simtong.global.DomainProperties
 import team.comit.simtong.global.DomainPropertiesPrefix
 
-/**
- * 가장 처음 테스트되는 클래스에 Import
- * Domain Properties 초기화
- */
-class DomainPropertiesInitialization {
+object DomainPropertiesInitialization {
     init {
         DomainProperties.putAll(
             mapOf(

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/auth/usecase/CheckAuthCodeUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/auth/usecase/CheckAuthCodeUseCaseTests.kt
@@ -4,19 +4,15 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.auth.exception.AuthCodeMismatchException
 import team.comit.simtong.domain.auth.model.AuthCode
 import team.comit.simtong.domain.auth.spi.CommandAuthCodeLimitPort
 import team.comit.simtong.domain.auth.spi.QueryAuthCodePort
+import team.comit.simtong.global.annotation.SimtongTest
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class CheckAuthCodeUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/auth/usecase/ReissueTokenUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/auth/usecase/ReissueTokenUseCaseTests.kt
@@ -7,15 +7,18 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
+import team.comit.simtong.domain.auth.dto.TokenResponse
 import team.comit.simtong.domain.auth.exception.RefreshTokenNotFoundException
 import team.comit.simtong.domain.auth.model.RefreshToken
-import team.comit.simtong.domain.auth.spi.QueryRefreshTokenPort
 import team.comit.simtong.domain.auth.spi.JwtPort
-import team.comit.simtong.domain.auth.dto.TokenResponse
+import team.comit.simtong.domain.auth.spi.QueryRefreshTokenPort
 import team.comit.simtong.domain.user.model.Authority
 import java.util.*
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class ReissueTokenUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/auth/usecase/ReissueTokenUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/auth/usecase/ReissueTokenUseCaseTests.kt
@@ -4,22 +4,19 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.auth.dto.TokenResponse
 import team.comit.simtong.domain.auth.exception.RefreshTokenNotFoundException
 import team.comit.simtong.domain.auth.model.RefreshToken
 import team.comit.simtong.domain.auth.spi.JwtPort
 import team.comit.simtong.domain.auth.spi.QueryRefreshTokenPort
 import team.comit.simtong.domain.user.model.Authority
-import java.util.*
+import team.comit.simtong.global.annotation.SimtongTest
+import java.util.Date
+import java.util.UUID
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class ReissueTokenUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/auth/usecase/SendAuthCodeUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/auth/usecase/SendAuthCodeUseCaseTests.kt
@@ -4,14 +4,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.willDoNothing
 import org.mockito.kotlin.any
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.auth.exception.CertifiedEmailException
 import team.comit.simtong.domain.auth.exception.ExceededSendAuthCodeRequestException
 import team.comit.simtong.domain.auth.model.AuthCode
@@ -20,9 +16,9 @@ import team.comit.simtong.domain.auth.spi.CommandAuthCodeLimitPort
 import team.comit.simtong.domain.auth.spi.CommandAuthCodePort
 import team.comit.simtong.domain.auth.spi.QueryAuthCodeLimitPort
 import team.comit.simtong.domain.auth.spi.SendEmailPort
+import team.comit.simtong.global.annotation.SimtongTest
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class SendAuthCodeUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/auth/usecase/SendAuthCodeUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/auth/usecase/SendAuthCodeUseCaseTests.kt
@@ -9,7 +9,9 @@ import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.willDoNothing
 import org.mockito.kotlin.any
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.auth.exception.CertifiedEmailException
 import team.comit.simtong.domain.auth.exception.ExceededSendAuthCodeRequestException
 import team.comit.simtong.domain.auth.model.AuthCode
@@ -19,6 +21,7 @@ import team.comit.simtong.domain.auth.spi.CommandAuthCodePort
 import team.comit.simtong.domain.auth.spi.QueryAuthCodeLimitPort
 import team.comit.simtong.domain.auth.spi.SendEmailPort
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class SendAuthCodeUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/file/usecase/UploadImageUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/file/usecase/UploadImageUseCaseTests.kt
@@ -4,18 +4,14 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.file.exception.FileInvalidExtensionException
 import team.comit.simtong.domain.file.spi.UploadFilePort
+import team.comit.simtong.global.annotation.SimtongTest
 import java.io.File
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class UploadImageUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/file/usecase/UploadImageUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/file/usecase/UploadImageUseCaseTests.kt
@@ -7,11 +7,14 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.file.exception.FileInvalidExtensionException
 import team.comit.simtong.domain.file.spi.UploadFilePort
 import java.io.File
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class UploadImageUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/menu/usecase/QueryMenuByMonthUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/menu/usecase/QueryMenuByMonthUseCaseTests.kt
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.menu.model.Menu
 import team.comit.simtong.domain.menu.spi.MenuQueryUserPort
 import team.comit.simtong.domain.menu.spi.MenuSecurityPort
@@ -18,6 +20,7 @@ import team.comit.simtong.domain.user.model.User
 import java.time.LocalDate
 import java.util.*
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class QueryMenuByMonthUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/menu/usecase/QueryMenuByMonthUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/menu/usecase/QueryMenuByMonthUseCaseTests.kt
@@ -4,12 +4,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.menu.model.Menu
 import team.comit.simtong.domain.menu.spi.MenuQueryUserPort
 import team.comit.simtong.domain.menu.spi.MenuSecurityPort
@@ -17,11 +13,11 @@ import team.comit.simtong.domain.menu.spi.QueryMenuPort
 import team.comit.simtong.domain.user.exception.UserNotFoundException
 import team.comit.simtong.domain.user.model.Authority
 import team.comit.simtong.domain.user.model.User
+import team.comit.simtong.global.annotation.SimtongTest
 import java.time.LocalDate
-import java.util.*
+import java.util.UUID
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class QueryMenuByMonthUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/menu/usecase/QueryPublicMenuUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/menu/usecase/QueryPublicMenuUseCaseTests.kt
@@ -3,19 +3,15 @@ package team.comit.simtong.domain.menu.usecase
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.menu.model.Menu
 import team.comit.simtong.domain.menu.spi.QueryMenuPort
+import team.comit.simtong.global.annotation.SimtongTest
 import java.time.LocalDate
-import java.util.*
+import java.util.UUID
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class QueryPublicMenuUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/menu/usecase/QueryPublicMenuUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/menu/usecase/QueryPublicMenuUseCaseTests.kt
@@ -6,12 +6,15 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.menu.model.Menu
 import team.comit.simtong.domain.menu.spi.QueryMenuPort
 import java.time.LocalDate
 import java.util.*
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class QueryPublicMenuUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/AddIndividualScheduleUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/AddIndividualScheduleUseCaseTests.kt
@@ -4,12 +4,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.schedule.dto.AddIndividualScheduleRequest
 import team.comit.simtong.domain.schedule.spi.CommandSchedulePort
 import team.comit.simtong.domain.schedule.spi.ScheduleQueryUserPort
@@ -17,11 +13,11 @@ import team.comit.simtong.domain.schedule.spi.ScheduleSecurityPort
 import team.comit.simtong.domain.user.exception.UserNotFoundException
 import team.comit.simtong.domain.user.model.Authority
 import team.comit.simtong.domain.user.model.User
+import team.comit.simtong.global.annotation.SimtongTest
 import java.time.LocalDate
 import java.util.UUID
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class AddIndividualScheduleUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/AddIndividualScheduleUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/AddIndividualScheduleUseCaseTests.kt
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.schedule.dto.AddIndividualScheduleRequest
 import team.comit.simtong.domain.schedule.spi.CommandSchedulePort
 import team.comit.simtong.domain.schedule.spi.ScheduleQueryUserPort
@@ -18,6 +20,7 @@ import team.comit.simtong.domain.user.model.User
 import java.time.LocalDate
 import java.util.UUID
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class AddIndividualScheduleUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/AddSpotScheduleUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/AddSpotScheduleUseCaseTests.kt
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.schedule.dto.AddSpotScheduleRequest
 import team.comit.simtong.domain.schedule.spi.CommandSchedulePort
 import team.comit.simtong.domain.schedule.spi.ScheduleQueryUserPort
@@ -19,6 +21,7 @@ import team.comit.simtong.domain.user.model.User
 import java.time.LocalDate
 import java.util.UUID
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class AddSpotScheduleUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/AddSpotScheduleUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/AddSpotScheduleUseCaseTests.kt
@@ -4,12 +4,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.schedule.dto.AddSpotScheduleRequest
 import team.comit.simtong.domain.schedule.spi.CommandSchedulePort
 import team.comit.simtong.domain.schedule.spi.ScheduleQueryUserPort
@@ -18,11 +14,11 @@ import team.comit.simtong.domain.user.exception.NotEnoughPermissionException
 import team.comit.simtong.domain.user.exception.UserNotFoundException
 import team.comit.simtong.domain.user.model.Authority
 import team.comit.simtong.domain.user.model.User
+import team.comit.simtong.global.annotation.SimtongTest
 import java.time.LocalDate
 import java.util.UUID
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class AddSpotScheduleUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/ChangeIndividualScheduleUseCaseTest.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/ChangeIndividualScheduleUseCaseTest.kt
@@ -8,7 +8,9 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.kotlin.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.schedule.dto.ChangeIndividualScheduleRequest
 import team.comit.simtong.domain.schedule.exception.NotScheduleOwnerException
 import team.comit.simtong.domain.schedule.exception.ScheduleNotFoundException
@@ -25,6 +27,7 @@ import java.time.LocalDate
 import java.time.LocalTime
 import java.util.UUID
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class ChangeIndividualScheduleUseCaseTest {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/ChangeIndividualScheduleUseCaseTest.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/ChangeIndividualScheduleUseCaseTest.kt
@@ -4,13 +4,9 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.kotlin.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.schedule.dto.ChangeIndividualScheduleRequest
 import team.comit.simtong.domain.schedule.exception.NotScheduleOwnerException
 import team.comit.simtong.domain.schedule.exception.ScheduleNotFoundException
@@ -23,12 +19,12 @@ import team.comit.simtong.domain.schedule.spi.ScheduleSecurityPort
 import team.comit.simtong.domain.user.exception.UserNotFoundException
 import team.comit.simtong.domain.user.model.Authority
 import team.comit.simtong.domain.user.model.User
+import team.comit.simtong.global.annotation.SimtongTest
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.UUID
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class ChangeIndividualScheduleUseCaseTest {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/ChangeSpotScheduleUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/ChangeSpotScheduleUseCaseTests.kt
@@ -4,12 +4,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.schedule.dto.ChangeSpotScheduleRequest
 import team.comit.simtong.domain.schedule.exception.NotScheduleOwnerException
 import team.comit.simtong.domain.schedule.exception.ScheduleNotFoundException
@@ -23,11 +19,11 @@ import team.comit.simtong.domain.user.exception.NotEnoughPermissionException
 import team.comit.simtong.domain.user.exception.UserNotFoundException
 import team.comit.simtong.domain.user.model.Authority
 import team.comit.simtong.domain.user.model.User
+import team.comit.simtong.global.annotation.SimtongTest
 import java.time.LocalDate
 import java.util.UUID
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class ChangeSpotScheduleUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/ChangeSpotScheduleUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/ChangeSpotScheduleUseCaseTests.kt
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.schedule.dto.ChangeSpotScheduleRequest
 import team.comit.simtong.domain.schedule.exception.NotScheduleOwnerException
 import team.comit.simtong.domain.schedule.exception.ScheduleNotFoundException
@@ -24,6 +26,7 @@ import team.comit.simtong.domain.user.model.User
 import java.time.LocalDate
 import java.util.UUID
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class ChangeSpotScheduleUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/EntireSpotScheduleUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/EntireSpotScheduleUseCaseTests.kt
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.schedule.dto.EntireSpotScheduleResponse
 import team.comit.simtong.domain.schedule.dto.SpotScheduleResponse
 import team.comit.simtong.domain.schedule.model.Scope
@@ -15,6 +17,7 @@ import team.comit.simtong.domain.schedule.vo.SpotSchedule
 import java.time.LocalDate
 import java.util.UUID
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class EntireSpotScheduleUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/EntireSpotScheduleUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/EntireSpotScheduleUseCaseTests.kt
@@ -3,22 +3,18 @@ package team.comit.simtong.domain.schedule.usecase
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.schedule.dto.EntireSpotScheduleResponse
 import team.comit.simtong.domain.schedule.dto.SpotScheduleResponse
 import team.comit.simtong.domain.schedule.model.Scope
 import team.comit.simtong.domain.schedule.spi.QuerySchedulePort
 import team.comit.simtong.domain.schedule.vo.SpotSchedule
+import team.comit.simtong.global.annotation.SimtongTest
 import java.time.LocalDate
 import java.util.UUID
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class EntireSpotScheduleUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/RemoveSpotScheduleUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/RemoveSpotScheduleUseCaseTests.kt
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.schedule.exception.ScheduleNotFoundException
 import team.comit.simtong.domain.schedule.model.Schedule
 import team.comit.simtong.domain.schedule.model.Scope
@@ -22,6 +24,7 @@ import team.comit.simtong.domain.user.model.User
 import java.time.LocalDate
 import java.util.UUID
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class RemoveSpotScheduleUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/RemoveSpotScheduleUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/RemoveSpotScheduleUseCaseTests.kt
@@ -4,12 +4,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.schedule.exception.ScheduleNotFoundException
 import team.comit.simtong.domain.schedule.model.Schedule
 import team.comit.simtong.domain.schedule.model.Scope
@@ -21,11 +17,11 @@ import team.comit.simtong.domain.user.exception.NotEnoughPermissionException
 import team.comit.simtong.domain.user.exception.UserNotFoundException
 import team.comit.simtong.domain.user.model.Authority
 import team.comit.simtong.domain.user.model.User
+import team.comit.simtong.global.annotation.SimtongTest
 import java.time.LocalDate
 import java.util.UUID
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class RemoveSpotScheduleUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/spot/usecase/ShowSpotListUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/spot/usecase/ShowSpotListUseCaseTests.kt
@@ -3,19 +3,15 @@ package team.comit.simtong.domain.spot.usecase
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.spot.dto.SpotResponse
 import team.comit.simtong.domain.spot.model.Spot
 import team.comit.simtong.domain.spot.spi.QuerySpotPort
+import team.comit.simtong.global.annotation.SimtongTest
 import java.util.UUID
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class ShowSpotListUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/spot/usecase/ShowSpotListUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/spot/usecase/ShowSpotListUseCaseTests.kt
@@ -6,12 +6,15 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.spot.dto.SpotResponse
 import team.comit.simtong.domain.spot.model.Spot
 import team.comit.simtong.domain.spot.spi.QuerySpotPort
 import java.util.UUID
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class ShowSpotListUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/AdminSignInUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/AdminSignInUseCaseTests.kt
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.auth.dto.TokenResponse
 import team.comit.simtong.domain.user.dto.SignInRequest
 import team.comit.simtong.domain.user.exception.DifferentPasswordException
@@ -20,6 +22,7 @@ import team.comit.simtong.domain.user.spi.UserJwtPort
 import team.comit.simtong.domain.user.spi.UserSecurityPort
 import java.util.*
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class AdminSignInUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/AdminSignInUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/AdminSignInUseCaseTests.kt
@@ -4,12 +4,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.auth.dto.TokenResponse
 import team.comit.simtong.domain.user.dto.SignInRequest
 import team.comit.simtong.domain.user.exception.DifferentPasswordException
@@ -20,10 +16,11 @@ import team.comit.simtong.domain.user.model.User
 import team.comit.simtong.domain.user.spi.QueryUserPort
 import team.comit.simtong.domain.user.spi.UserJwtPort
 import team.comit.simtong.domain.user.spi.UserSecurityPort
-import java.util.*
+import team.comit.simtong.global.annotation.SimtongTest
+import java.util.Date
+import java.util.UUID
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class AdminSignInUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ChangeEmailUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ChangeEmailUseCaseTests.kt
@@ -4,12 +4,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.auth.exception.RequiredNewEmailAuthenticationException
 import team.comit.simtong.domain.auth.exception.UncertifiedEmailException
 import team.comit.simtong.domain.auth.exception.UsedEmailException
@@ -22,10 +18,10 @@ import team.comit.simtong.domain.user.model.User
 import team.comit.simtong.domain.user.spi.CommandUserPort
 import team.comit.simtong.domain.user.spi.QueryUserPort
 import team.comit.simtong.domain.user.spi.UserSecurityPort
+import team.comit.simtong.global.annotation.SimtongTest
 import java.util.UUID
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class ChangeEmailUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ChangeEmailUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ChangeEmailUseCaseTests.kt
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.auth.exception.RequiredNewEmailAuthenticationException
 import team.comit.simtong.domain.auth.exception.UncertifiedEmailException
 import team.comit.simtong.domain.auth.exception.UsedEmailException
@@ -22,6 +24,7 @@ import team.comit.simtong.domain.user.spi.QueryUserPort
 import team.comit.simtong.domain.user.spi.UserSecurityPort
 import java.util.UUID
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class ChangeEmailUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ChangeNicknameUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ChangeNicknameUseCaseTests.kt
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.auth.exception.UsedNicknameException
 import team.comit.simtong.domain.user.dto.ChangeNicknameRequest
 import team.comit.simtong.domain.user.exception.UserNotFoundException
@@ -18,6 +20,7 @@ import team.comit.simtong.domain.user.spi.QueryUserPort
 import team.comit.simtong.domain.user.spi.UserSecurityPort
 import java.util.UUID
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class ChangeNicknameUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ChangeNicknameUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ChangeNicknameUseCaseTests.kt
@@ -4,12 +4,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.auth.exception.UsedNicknameException
 import team.comit.simtong.domain.user.dto.ChangeNicknameRequest
 import team.comit.simtong.domain.user.exception.UserNotFoundException
@@ -18,10 +14,10 @@ import team.comit.simtong.domain.user.model.User
 import team.comit.simtong.domain.user.spi.CommandUserPort
 import team.comit.simtong.domain.user.spi.QueryUserPort
 import team.comit.simtong.domain.user.spi.UserSecurityPort
+import team.comit.simtong.global.annotation.SimtongTest
 import java.util.UUID
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class ChangeNicknameUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ChangePasswordUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ChangePasswordUseCaseTests.kt
@@ -4,12 +4,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.user.dto.ChangePasswordRequest
 import team.comit.simtong.domain.user.exception.DifferentPasswordException
 import team.comit.simtong.domain.user.exception.UserNotFoundException
@@ -18,10 +14,10 @@ import team.comit.simtong.domain.user.model.User
 import team.comit.simtong.domain.user.spi.CommandUserPort
 import team.comit.simtong.domain.user.spi.QueryUserPort
 import team.comit.simtong.domain.user.spi.UserSecurityPort
+import team.comit.simtong.global.annotation.SimtongTest
 import java.util.UUID
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class ChangePasswordUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ChangePasswordUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ChangePasswordUseCaseTests.kt
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.user.dto.ChangePasswordRequest
 import team.comit.simtong.domain.user.exception.DifferentPasswordException
 import team.comit.simtong.domain.user.exception.UserNotFoundException
@@ -18,6 +20,7 @@ import team.comit.simtong.domain.user.spi.QueryUserPort
 import team.comit.simtong.domain.user.spi.UserSecurityPort
 import java.util.UUID
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class ChangePasswordUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ChangeProfileImageUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ChangeProfileImageUseCaseTests.kt
@@ -4,12 +4,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.file.exception.NotFoundFilePathException
 import team.comit.simtong.domain.file.spi.CheckFilePort
 import team.comit.simtong.domain.user.dto.ChangeProfileImageRequest
@@ -19,10 +15,10 @@ import team.comit.simtong.domain.user.model.User
 import team.comit.simtong.domain.user.spi.CommandUserPort
 import team.comit.simtong.domain.user.spi.QueryUserPort
 import team.comit.simtong.domain.user.spi.UserSecurityPort
+import team.comit.simtong.global.annotation.SimtongTest
 import java.util.UUID
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class ChangeProfileImageUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ChangeProfileImageUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ChangeProfileImageUseCaseTests.kt
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.file.exception.NotFoundFilePathException
 import team.comit.simtong.domain.file.spi.CheckFilePort
 import team.comit.simtong.domain.user.dto.ChangeProfileImageRequest
@@ -19,6 +21,7 @@ import team.comit.simtong.domain.user.spi.QueryUserPort
 import team.comit.simtong.domain.user.spi.UserSecurityPort
 import java.util.UUID
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class ChangeProfileImageUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ChangeSpotUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ChangeSpotUseCaseTests.kt
@@ -9,7 +9,7 @@ import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
+import team.comit.simtong.global.DomainPropertiesInitialization
 import team.comit.simtong.domain.spot.exception.SpotNotFoundException
 import team.comit.simtong.domain.user.exception.UserNotFoundException
 import team.comit.simtong.domain.user.model.Authority

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ChangeSpotUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ChangeSpotUseCaseTests.kt
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.spot.exception.SpotNotFoundException
 import team.comit.simtong.domain.user.exception.UserNotFoundException
 import team.comit.simtong.domain.user.model.Authority
@@ -18,6 +20,7 @@ import team.comit.simtong.domain.user.spi.UserQuerySpotPort
 import team.comit.simtong.domain.user.spi.UserSecurityPort
 import java.util.*
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class ChangeSpotUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/CheckEmailDuplicationUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/CheckEmailDuplicationUseCaseTests.kt
@@ -4,17 +4,13 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.auth.exception.UsedEmailException
 import team.comit.simtong.domain.user.spi.QueryUserPort
+import team.comit.simtong.global.annotation.SimtongTest
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class CheckEmailDuplicationUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/CheckEmailDuplicationUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/CheckEmailDuplicationUseCaseTests.kt
@@ -7,10 +7,13 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.auth.exception.UsedEmailException
 import team.comit.simtong.domain.user.spi.QueryUserPort
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class CheckEmailDuplicationUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/CheckMatchedAccountUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/CheckMatchedAccountUseCaseTests.kt
@@ -7,11 +7,14 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.user.dto.CheckMatchedAccountRequest
 import team.comit.simtong.domain.user.exception.UserNotFoundException
 import team.comit.simtong.domain.user.spi.QueryUserPort
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class CheckMatchedAccountUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/CheckMatchedAccountUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/CheckMatchedAccountUseCaseTests.kt
@@ -4,18 +4,14 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.user.dto.CheckMatchedAccountRequest
 import team.comit.simtong.domain.user.exception.UserNotFoundException
 import team.comit.simtong.domain.user.spi.QueryUserPort
+import team.comit.simtong.global.annotation.SimtongTest
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class CheckMatchedAccountUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/CheckNicknameDuplicationUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/CheckNicknameDuplicationUseCaseTests.kt
@@ -7,11 +7,13 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.auth.exception.UsedEmailException
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.auth.exception.UsedNicknameException
 import team.comit.simtong.domain.user.spi.QueryUserPort
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class CheckNicknameDuplicationUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/CheckNicknameDuplicationUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/CheckNicknameDuplicationUseCaseTests.kt
@@ -4,17 +4,13 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.auth.exception.UsedNicknameException
 import team.comit.simtong.domain.user.spi.QueryUserPort
+import team.comit.simtong.global.annotation.SimtongTest
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class CheckNicknameDuplicationUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/FindEmployeeNumberUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/FindEmployeeNumberUseCaseTests.kt
@@ -4,21 +4,17 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.user.dto.FindEmployeeNumberRequest
 import team.comit.simtong.domain.user.exception.UserNotFoundException
 import team.comit.simtong.domain.user.model.Authority
 import team.comit.simtong.domain.user.model.User
 import team.comit.simtong.domain.user.spi.QueryUserPort
-import java.util.*
+import team.comit.simtong.global.annotation.SimtongTest
+import java.util.UUID
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class FindEmployeeNumberUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/FindEmployeeNumberUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/FindEmployeeNumberUseCaseTests.kt
@@ -7,14 +7,17 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
+import team.comit.simtong.domain.user.dto.FindEmployeeNumberRequest
 import team.comit.simtong.domain.user.exception.UserNotFoundException
 import team.comit.simtong.domain.user.model.Authority
 import team.comit.simtong.domain.user.model.User
 import team.comit.simtong.domain.user.spi.QueryUserPort
-import team.comit.simtong.domain.user.dto.FindEmployeeNumberRequest
 import java.util.*
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class FindEmployeeNumberUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ResetPasswordUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ResetPasswordUseCaseTests.kt
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.auth.exception.RequiredNewEmailAuthenticationException
 import team.comit.simtong.domain.auth.exception.UncertifiedEmailException
 import team.comit.simtong.domain.auth.model.AuthCodeLimit
@@ -21,6 +23,7 @@ import team.comit.simtong.domain.user.spi.UserQueryAuthCodeLimitPort
 import team.comit.simtong.domain.user.spi.UserSecurityPort
 import java.util.UUID
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class ResetPasswordUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ResetPasswordUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/ResetPasswordUseCaseTests.kt
@@ -4,12 +4,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.auth.exception.RequiredNewEmailAuthenticationException
 import team.comit.simtong.domain.auth.exception.UncertifiedEmailException
 import team.comit.simtong.domain.auth.model.AuthCodeLimit
@@ -21,10 +17,10 @@ import team.comit.simtong.domain.user.spi.CommandUserPort
 import team.comit.simtong.domain.user.spi.QueryUserPort
 import team.comit.simtong.domain.user.spi.UserQueryAuthCodeLimitPort
 import team.comit.simtong.domain.user.spi.UserSecurityPort
+import team.comit.simtong.global.annotation.SimtongTest
 import java.util.UUID
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class ResetPasswordUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/SignInUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/SignInUseCaseTests.kt
@@ -4,12 +4,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.auth.dto.TokenResponse
 import team.comit.simtong.domain.user.dto.SignInRequest
 import team.comit.simtong.domain.user.exception.DifferentPasswordException
@@ -20,10 +16,10 @@ import team.comit.simtong.domain.user.model.User
 import team.comit.simtong.domain.user.spi.QueryUserPort
 import team.comit.simtong.domain.user.spi.UserJwtPort
 import team.comit.simtong.domain.user.spi.UserSecurityPort
+import team.comit.simtong.global.annotation.SimtongTest
 import java.util.*
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class SignInUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/SignInUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/SignInUseCaseTests.kt
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.auth.dto.TokenResponse
 import team.comit.simtong.domain.user.dto.SignInRequest
 import team.comit.simtong.domain.user.exception.DifferentPasswordException
@@ -20,6 +22,7 @@ import team.comit.simtong.domain.user.spi.UserJwtPort
 import team.comit.simtong.domain.user.spi.UserSecurityPort
 import java.util.*
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class SignInUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/SignUpUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/SignUpUseCaseTests.kt
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.auth.dto.TokenResponse
 import team.comit.simtong.domain.auth.exception.RequiredNewEmailAuthenticationException
 import team.comit.simtong.domain.auth.exception.UncertifiedEmailException
@@ -29,6 +31,7 @@ import team.comit.simtong.domain.user.spi.UserQueryTeamPort
 import team.comit.simtong.domain.user.spi.UserSecurityPort
 import java.util.*
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class SignUpUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/SignUpUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/SignUpUseCaseTests.kt
@@ -4,12 +4,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.auth.dto.TokenResponse
 import team.comit.simtong.domain.auth.exception.RequiredNewEmailAuthenticationException
 import team.comit.simtong.domain.auth.exception.UncertifiedEmailException
@@ -29,10 +25,10 @@ import team.comit.simtong.domain.user.spi.UserQueryAuthCodeLimitPort
 import team.comit.simtong.domain.user.spi.UserQuerySpotPort
 import team.comit.simtong.domain.user.spi.UserQueryTeamPort
 import team.comit.simtong.domain.user.spi.UserSecurityPort
+import team.comit.simtong.global.annotation.SimtongTest
 import java.util.*
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class SignUpUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/UserInfoUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/UserInfoUseCaseTests.kt
@@ -4,12 +4,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Import
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.spot.exception.SpotNotFoundException
 import team.comit.simtong.domain.spot.model.Spot
 import team.comit.simtong.domain.user.exception.UserNotFoundException
@@ -18,10 +14,10 @@ import team.comit.simtong.domain.user.model.User
 import team.comit.simtong.domain.user.spi.QueryUserPort
 import team.comit.simtong.domain.user.spi.UserQuerySpotPort
 import team.comit.simtong.domain.user.spi.UserSecurityPort
+import team.comit.simtong.global.annotation.SimtongTest
 import java.util.UUID
 
-@Import(DomainPropertiesInitialization::class)
-@ExtendWith(SpringExtension::class)
+@SimtongTest
 class UserInfoUseCaseTests {
 
     @MockBean

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/UserInfoUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/user/usecase/UserInfoUseCaseTests.kt
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.BDDMockito.given
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.domain.DomainPropertiesInitialization
 import team.comit.simtong.domain.spot.exception.SpotNotFoundException
 import team.comit.simtong.domain.spot.model.Spot
 import team.comit.simtong.domain.user.exception.UserNotFoundException
@@ -18,6 +20,7 @@ import team.comit.simtong.domain.user.spi.UserQuerySpotPort
 import team.comit.simtong.domain.user.spi.UserSecurityPort
 import java.util.UUID
 
+@Import(DomainPropertiesInitialization::class)
 @ExtendWith(SpringExtension::class)
 class UserInfoUseCaseTests {
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/global/DomainPropertiesInitialization.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/global/DomainPropertiesInitialization.kt
@@ -1,4 +1,4 @@
-package team.comit.simtong.domain
+package team.comit.simtong.global
 
 import team.comit.simtong.global.DomainProperties
 import team.comit.simtong.global.DomainPropertiesPrefix

--- a/simtong-application/src/test/kotlin/team/comit/simtong/global/annotation/SimtongTest.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/global/annotation/SimtongTest.kt
@@ -1,0 +1,13 @@
+package team.comit.simtong.global.annotation
+
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import team.comit.simtong.global.DomainPropertiesInitialization
+
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@ExtendWith(SpringExtension::class)
+@Import(DomainPropertiesInitialization::class)
+annotation class SimtongTest


### PR DESCRIPTION
## 작업 내용 설명
- [x] Domain Properties Initialization 모든 테스트 케이스 적용

## 주요 변경 사항
- Domain Properties Initialization javadoc 삭제
- Application 계층 Test Case Import Domain Properties Initialization

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [ ] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #158 