### PR TITLE
merge: (#166) 개인 + 일정 조회 API

### DIFF
--- a/simtong-application/src/main/kotlin/team/comit/simtong/domain/schedule/dto/QueryEntireSpotScheduleResponse.kt
+++ b/simtong-application/src/main/kotlin/team/comit/simtong/domain/schedule/dto/QueryEntireSpotScheduleResponse.kt
@@ -5,13 +5,13 @@ import java.util.UUID
 
 /**
  *
- * 모든 지점 일정 조회 정보를 전송하는 EntireSpotScheduleResponse
+ * 모든 지점 일정 조회 정보를 전송하는 QueryEntireSpotScheduleResponse
  *
  * @author Chokyunghyeon
  * @date 2022/11/26
  * @version 1.0.0
  **/
-data class EntireSpotScheduleResponse(
+data class QueryEntireSpotScheduleResponse(
     val schedules: List<SpotScheduleResponse>
 )
 

--- a/simtong-application/src/main/kotlin/team/comit/simtong/domain/schedule/dto/QueryIndividualSpotScheduleResponse.kt
+++ b/simtong-application/src/main/kotlin/team/comit/simtong/domain/schedule/dto/QueryIndividualSpotScheduleResponse.kt
@@ -1,0 +1,34 @@
+package team.comit.simtong.domain.schedule.dto
+
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ *
+ * 개인 일정과 소속 지점의 일정 조회 정보를 다루는 QueryIndividualSpotScheduleResponse
+ *
+ * @author kimbeomjin
+ * @date 2022/12/02
+ * @version 1.0.0
+ **/
+data class QueryIndividualSpotScheduleResponse(
+    val schedules: List<ScheduleResponse>
+)
+
+/**
+ *
+ * 일정 조회 정보를 다루는 ScheduleResponse
+ *
+ * @author kimbeomjin
+ * @date 2022/12/02
+ * @version 1.0.0
+ **/
+data class ScheduleResponse(
+    val id: UUID,
+
+    val startAt: LocalDate,
+
+    val endAt: LocalDate,
+
+    val title: String
+)

--- a/simtong-application/src/main/kotlin/team/comit/simtong/domain/schedule/usecase/QueryEntireSpotScheduleUseCase.kt
+++ b/simtong-application/src/main/kotlin/team/comit/simtong/domain/schedule/usecase/QueryEntireSpotScheduleUseCase.kt
@@ -1,6 +1,6 @@
 package team.comit.simtong.domain.schedule.usecase
 
-import team.comit.simtong.domain.schedule.dto.EntireSpotScheduleResponse
+import team.comit.simtong.domain.schedule.dto.QueryEntireSpotScheduleResponse
 import team.comit.simtong.domain.schedule.dto.SpotScheduleResponse
 import team.comit.simtong.domain.schedule.model.Scope
 import team.comit.simtong.domain.schedule.spi.QuerySchedulePort
@@ -9,18 +9,18 @@ import java.time.LocalDate
 
 /**
  *
- * 모든 지점 일정 조회 요청을 담당하는 QuerySpotScheduleUseCase
+ * 모든 지점 일정 조회 요청을 담당하는 QueryEntireSpotScheduleUseCase
  *
  * @author Chokyunghyeon
  * @date 2022/11/26
  * @version 1.0.0
  **/
 @ReadOnlyUseCase
-class EntireSpotScheduleUseCase(
+class QueryEntireSpotScheduleUseCase(
     private val querySchedulePort: QuerySchedulePort
 ) {
 
-    fun execute(date: LocalDate): EntireSpotScheduleResponse {
+    fun execute(date: LocalDate): QueryEntireSpotScheduleResponse {
         val list = querySchedulePort.querySchedulesByMonthAndScope(date, Scope.ENTIRE)
 
         val response = list.map {
@@ -36,7 +36,7 @@ class EntireSpotScheduleUseCase(
             )
         }
 
-        return EntireSpotScheduleResponse(response)
+        return QueryEntireSpotScheduleResponse(response)
     }
 
 }

--- a/simtong-application/src/main/kotlin/team/comit/simtong/domain/schedule/usecase/QueryIndividualSpotScheduleUseCase.kt
+++ b/simtong-application/src/main/kotlin/team/comit/simtong/domain/schedule/usecase/QueryIndividualSpotScheduleUseCase.kt
@@ -36,10 +36,11 @@ class QueryIndividualSpotScheduleUseCase(
         val ownSpotSchedules = querySchedulePort.querySchedulesByMonthAndSpotIdAndScope(
             date, user.spotId, Scope.INDIVIDUAL
         )
-            .plus(individualSchedules) // 개인 일정과 소속 지점 일정 합치기
+
+        val schedules = ownSpotSchedules.union(individualSchedules) // 개인 일정과 소속 지점 일정 합치면서 중복 제거
             .sortedBy { it.startAt } // 시작일 기준 오름차순으로 정렬
 
-        val response = ownSpotSchedules.map {
+        val response = schedules.map {
             ScheduleResponse(
                 id = it.id,
                 startAt = it.startAt,

--- a/simtong-application/src/main/kotlin/team/comit/simtong/domain/schedule/usecase/QueryIndividualSpotScheduleUseCase.kt
+++ b/simtong-application/src/main/kotlin/team/comit/simtong/domain/schedule/usecase/QueryIndividualSpotScheduleUseCase.kt
@@ -1,0 +1,48 @@
+package team.comit.simtong.domain.schedule.usecase
+
+import team.comit.simtong.domain.schedule.dto.QueryIndividualSpotScheduleResponse
+import team.comit.simtong.domain.schedule.dto.ScheduleResponse
+import team.comit.simtong.domain.schedule.spi.QuerySchedulePort
+import team.comit.simtong.domain.schedule.spi.ScheduleQueryUserPort
+import team.comit.simtong.domain.schedule.spi.ScheduleSecurityPort
+import team.comit.simtong.domain.user.exception.UserNotFoundException
+import team.comit.simtong.global.annotation.ReadOnlyUseCase
+import java.time.LocalDate
+
+/**
+ *
+ * 개인 일정과 소속 지점 일정을 조회하는 QueryIndividualSpotScheduleUseCase
+ *
+ * @author kimbeomjin
+ * @date 2022/12/02
+ * @version 1.0.0
+ **/
+@ReadOnlyUseCase
+class QueryIndividualSpotScheduleUseCase(
+    private val querySchedulePort: QuerySchedulePort,
+    private val queryUserPort: ScheduleQueryUserPort,
+    private val securityPort: ScheduleSecurityPort
+) {
+
+    fun execute(date: LocalDate): QueryIndividualSpotScheduleResponse {
+        val user = queryUserPort.queryUserById(securityPort.getCurrentUserId())
+            ?: throw UserNotFoundException.EXCEPTION
+
+        val individualSchedules = querySchedulePort.querySchedulesByMonthAndUserId(date, user.id)
+
+        val ownSpotSchedules = querySchedulePort.querySchedulesByMonthAndSpotId(date, user.spotId)
+            .plus(individualSchedules) // 개인 일정과 소속 지점 일정 합치기
+            .sortedBy { it.startAt } // 시작일 기준 오름차순으로 정렬
+
+        val response = ownSpotSchedules.map {
+            ScheduleResponse(
+                id = it.id,
+                startAt = it.startAt,
+                endAt = it.endAt,
+                title = it.title
+            )
+        }
+
+        return QueryIndividualSpotScheduleResponse(response)
+    }
+}

--- a/simtong-application/src/main/kotlin/team/comit/simtong/domain/schedule/usecase/QueryIndividualSpotScheduleUseCase.kt
+++ b/simtong-application/src/main/kotlin/team/comit/simtong/domain/schedule/usecase/QueryIndividualSpotScheduleUseCase.kt
@@ -2,6 +2,7 @@ package team.comit.simtong.domain.schedule.usecase
 
 import team.comit.simtong.domain.schedule.dto.QueryIndividualSpotScheduleResponse
 import team.comit.simtong.domain.schedule.dto.ScheduleResponse
+import team.comit.simtong.domain.schedule.model.Scope
 import team.comit.simtong.domain.schedule.spi.QuerySchedulePort
 import team.comit.simtong.domain.schedule.spi.ScheduleQueryUserPort
 import team.comit.simtong.domain.schedule.spi.ScheduleSecurityPort
@@ -28,9 +29,13 @@ class QueryIndividualSpotScheduleUseCase(
         val user = queryUserPort.queryUserById(securityPort.getCurrentUserId())
             ?: throw UserNotFoundException.EXCEPTION
 
-        val individualSchedules = querySchedulePort.querySchedulesByMonthAndUserId(date, user.id)
+        val individualSchedules = querySchedulePort.querySchedulesByMonthAndUserIdAndScope(
+            date, user.id, Scope.INDIVIDUAL
+        )
 
-        val ownSpotSchedules = querySchedulePort.querySchedulesByMonthAndSpotId(date, user.spotId)
+        val ownSpotSchedules = querySchedulePort.querySchedulesByMonthAndSpotIdAndScope(
+            date, user.spotId, Scope.INDIVIDUAL
+        )
             .plus(individualSchedules) // 개인 일정과 소속 지점 일정 합치기
             .sortedBy { it.startAt } // 시작일 기준 오름차순으로 정렬
 

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/QueryEntireSpotScheduleUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/QueryEntireSpotScheduleUseCaseTests.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.given
 import org.springframework.boot.test.mock.mockito.MockBean
-import team.comit.simtong.domain.schedule.dto.EntireSpotScheduleResponse
+import team.comit.simtong.domain.schedule.dto.QueryEntireSpotScheduleResponse
 import team.comit.simtong.domain.schedule.dto.SpotScheduleResponse
 import team.comit.simtong.domain.schedule.model.Scope
 import team.comit.simtong.domain.schedule.spi.QuerySchedulePort
@@ -15,12 +15,12 @@ import java.time.LocalDate
 import java.util.UUID
 
 @SimtongTest
-class EntireSpotScheduleUseCaseTests {
+class QueryEntireSpotScheduleUseCaseTests {
 
     @MockBean
     private lateinit var querySchedulePort: QuerySchedulePort
 
-    private lateinit var entireSpotScheduleUseCase: EntireSpotScheduleUseCase
+    private lateinit var queryEntireSpotScheduleUseCase: QueryEntireSpotScheduleUseCase
 
     private val date: LocalDate = LocalDate.now()
 
@@ -37,8 +37,8 @@ class EntireSpotScheduleUseCaseTests {
         )
     )
 
-    private val responseStub: EntireSpotScheduleResponse by lazy {
-        EntireSpotScheduleResponse(
+    private val responseStub: QueryEntireSpotScheduleResponse by lazy {
+        QueryEntireSpotScheduleResponse(
             listOf(
                 SpotScheduleResponse(
                     id = uuid,
@@ -56,7 +56,7 @@ class EntireSpotScheduleUseCaseTests {
 
     @BeforeEach
     fun setUp() {
-        entireSpotScheduleUseCase = EntireSpotScheduleUseCase(querySchedulePort)
+        queryEntireSpotScheduleUseCase = QueryEntireSpotScheduleUseCase(querySchedulePort)
     }
 
     @Test
@@ -66,7 +66,7 @@ class EntireSpotScheduleUseCaseTests {
             .willReturn(spotScheduleListStub)
 
         // when
-        val response = entireSpotScheduleUseCase.execute(date)
+        val response = queryEntireSpotScheduleUseCase.execute(date)
 
         // then
         assertEquals(response, responseStub)

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/QueryIndividualSpotScheduleUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/schedule/usecase/QueryIndividualSpotScheduleUseCaseTests.kt
@@ -1,0 +1,134 @@
+package team.comit.simtong.domain.schedule.usecase
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.given
+import org.springframework.boot.test.mock.mockito.MockBean
+import team.comit.simtong.domain.schedule.dto.QueryIndividualSpotScheduleResponse
+import team.comit.simtong.domain.schedule.dto.ScheduleResponse
+import team.comit.simtong.domain.schedule.model.Schedule
+import team.comit.simtong.domain.schedule.model.Scope
+import team.comit.simtong.domain.schedule.spi.QuerySchedulePort
+import team.comit.simtong.domain.schedule.spi.ScheduleQueryUserPort
+import team.comit.simtong.domain.schedule.spi.ScheduleSecurityPort
+import team.comit.simtong.domain.user.exception.UserNotFoundException
+import team.comit.simtong.domain.user.model.Authority
+import team.comit.simtong.domain.user.model.User
+import team.comit.simtong.global.annotation.SimtongTest
+import java.time.LocalDate
+import java.util.*
+
+@SimtongTest
+class QueryIndividualSpotScheduleUseCaseTests {
+
+    @MockBean
+    private lateinit var querySchedulePort: QuerySchedulePort
+
+    @MockBean
+    private lateinit var queryUserPort: ScheduleQueryUserPort
+
+    @MockBean
+    private lateinit var securityPort: ScheduleSecurityPort
+
+    private lateinit var queryIndividualSpotScheduleUseCase: QueryIndividualSpotScheduleUseCase
+
+    private val date: LocalDate = LocalDate.now()
+
+    private val userId: UUID = UUID.randomUUID()
+
+    private val spotId: UUID = UUID.randomUUID()
+
+    private val scheduleId: UUID = UUID.randomUUID()
+
+    private val userStub: User by lazy {
+        User(
+            id = userId,
+            nickname = "test nickname",
+            name = "test name",
+            email = "test@test.com",
+            password = "test password",
+            employeeNumber = 1234567890,
+            authority = Authority.ROLE_COMMON,
+            spotId = UUID.randomUUID(),
+            teamId = UUID.randomUUID(),
+            profileImagePath = "test profile image"
+        )
+    }
+
+    private val scheduleStub: Schedule by lazy {
+        Schedule(
+            id = scheduleId,
+            userId = userId,
+            spotId = spotId,
+            title = "test title",
+            scope = Scope.INDIVIDUAL,
+            startAt = date,
+            endAt = date,
+            alarmTime = Schedule.DEFAULT_ALARM_TIME
+        )
+    }
+
+    private val responseStub by lazy {
+        QueryIndividualSpotScheduleResponse(
+            listOf(
+                ScheduleResponse(
+                    id = scheduleId,
+                    startAt = date,
+                    endAt = date,
+                    title = "test title"
+                )
+            )
+        )
+    }
+
+    @BeforeEach
+    fun setUp() {
+        queryIndividualSpotScheduleUseCase = QueryIndividualSpotScheduleUseCase(
+            querySchedulePort, queryUserPort, securityPort
+        )
+    }
+
+    @Test
+    fun `개인 + 지점 일정 조회 성공`() {
+        // given
+        given(securityPort.getCurrentUserId())
+            .willReturn(userId)
+
+        given(queryUserPort.queryUserById(userId))
+            .willReturn(userStub)
+
+        given(querySchedulePort.querySchedulesByMonthAndUserIdAndScope(date, userStub.id, Scope.INDIVIDUAL))
+            .willReturn(
+                listOf(scheduleStub)
+            )
+
+        given(querySchedulePort.querySchedulesByMonthAndSpotIdAndScope(date, userStub.spotId, Scope.INDIVIDUAL))
+            .willReturn(
+                listOf(scheduleStub)
+            )
+
+        // when
+        val response = queryIndividualSpotScheduleUseCase.execute(date)
+
+        // then
+        assertThat(response).isEqualTo(responseStub)
+    }
+
+    @Test
+    fun `유저가 존재하지 않음`() {
+        // given
+        given(securityPort.getCurrentUserId())
+            .willReturn(userId)
+
+        given(queryUserPort.queryUserById(userId))
+            .willReturn(null)
+
+        // when & then
+        assertThrows<UserNotFoundException> {
+            queryIndividualSpotScheduleUseCase.execute(date)
+        }
+    }
+
+}

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/schedule/spi/QuerySchedulePort.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/schedule/spi/QuerySchedulePort.kt
@@ -20,8 +20,8 @@ interface QuerySchedulePort {
 
     fun querySchedulesByMonthAndScope(date: LocalDate, scope: Scope): List<SpotSchedule>
 
-    fun querySchedulesByMonthAndSpotId(date: LocalDate, spotId: UUID): List<Schedule>
+    fun querySchedulesByMonthAndSpotIdAndScope(date: LocalDate, spotId: UUID, scope: Scope): List<Schedule>
 
-    fun querySchedulesByMonthAndUserId(date: LocalDate, userId: UUID): List<Schedule>
+    fun querySchedulesByMonthAndUserIdAndScope(date: LocalDate, userId: UUID, scope: Scope): List<Schedule>
 
 }

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/schedule/spi/QuerySchedulePort.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/schedule/spi/QuerySchedulePort.kt
@@ -20,4 +20,8 @@ interface QuerySchedulePort {
 
     fun querySchedulesByMonthAndScope(date: LocalDate, scope: Scope): List<SpotSchedule>
 
+    fun querySchedulesByMonthAndSpotId(date: LocalDate, spotId: UUID): List<Schedule>
+
+    fun querySchedulesByMonthAndUserId(date: LocalDate, userId: UUID): List<Schedule>
+
 }

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/global/security/SecurityConfig.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/global/security/SecurityConfig.kt
@@ -79,6 +79,7 @@ class SecurityConfig(
 
             // schedules
             .antMatchers(HttpMethod.POST, "/schedules").hasRole(ROLE_COMMON.role)
+            .antMatchers(HttpMethod.GET, "/schedules").hasRole(ROLE_COMMON.role)
             .antMatchers(HttpMethod.PUT, "/schedules/{schedule-id}").hasRole(ROLE_COMMON.role)
             .antMatchers(HttpMethod.GET, "/schedules/spots").hasAnyRole(ROLE_ADMIN.role, ROLE_SUPER.role)
             .antMatchers(HttpMethod.POST, "/schedules/spots/{spot-id}").hasAnyRole(ROLE_ADMIN.role, ROLE_SUPER.role)

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/schedule/SchedulePersistenceAdapter.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/schedule/SchedulePersistenceAdapter.kt
@@ -71,12 +71,13 @@ class SchedulePersistenceAdapter(
             .fetch()
     }
 
-    override fun querySchedulesByMonthAndSpotId(date: LocalDate, spotId: UUID): List<Schedule> {
+    override fun querySchedulesByMonthAndSpotIdAndScope(date: LocalDate, spotId: UUID, scope: Scope): List<Schedule> {
         return queryFactory
             .selectFrom(schedule)
             .join(spot)
             .on(schedule.spot.id.eq(spotId))
             .where(
+                schedule.scope.eq(scope),
                 dateFilter(date)
             )
             .orderBy(schedule.startAt.asc())
@@ -84,11 +85,12 @@ class SchedulePersistenceAdapter(
             .map { scheduleMapper.toDomain(it)!! }
     }
 
-    override fun querySchedulesByMonthAndUserId(date: LocalDate, userId: UUID): List<Schedule> {
+    override fun querySchedulesByMonthAndUserIdAndScope(date: LocalDate, userId: UUID, scope: Scope): List<Schedule> {
         return queryFactory
             .selectFrom(schedule)
             .where(
                 schedule.user.id.eq(userId),
+                schedule.scope.eq(scope),
                 dateFilter(date)
             )
             .orderBy(schedule.startAt.asc())

--- a/simtong-presentation/src/main/kotlin/team/comit/simtong/domain/schedule/WebScheduleAdapter.kt
+++ b/simtong-presentation/src/main/kotlin/team/comit/simtong/domain/schedule/WebScheduleAdapter.kt
@@ -15,7 +15,7 @@ import team.comit.simtong.domain.schedule.dto.AddIndividualScheduleRequest
 import team.comit.simtong.domain.schedule.dto.AddSpotScheduleRequest
 import team.comit.simtong.domain.schedule.dto.ChangeIndividualScheduleRequest
 import team.comit.simtong.domain.schedule.dto.ChangeSpotScheduleRequest
-import team.comit.simtong.domain.schedule.dto.EntireSpotScheduleResponse
+import team.comit.simtong.domain.schedule.dto.QueryEntireSpotScheduleResponse
 import team.comit.simtong.domain.schedule.dto.request.AddIndividualScheduleWebRequest
 import team.comit.simtong.domain.schedule.dto.request.AddSpotScheduleWebRequest
 import team.comit.simtong.domain.schedule.dto.request.ChangeIndividualScheduleWebRequest
@@ -24,7 +24,7 @@ import team.comit.simtong.domain.schedule.usecase.AddIndividualScheduleUseCase
 import team.comit.simtong.domain.schedule.usecase.AddSpotScheduleUseCase
 import team.comit.simtong.domain.schedule.usecase.ChangeIndividualScheduleUseCase
 import team.comit.simtong.domain.schedule.usecase.ChangeSpotScheduleUseCase
-import team.comit.simtong.domain.schedule.usecase.EntireSpotScheduleUseCase
+import team.comit.simtong.domain.schedule.usecase.QueryEntireSpotScheduleUseCase
 import team.comit.simtong.domain.schedule.usecase.RemoveSpotScheduleUseCase
 import java.time.LocalDate
 import java.util.UUID
@@ -43,7 +43,7 @@ import javax.validation.Valid
 class WebScheduleAdapter(
     private val addIndividualScheduleUseCase: AddIndividualScheduleUseCase,
     private val changeIndividualScheduleUseCase: ChangeIndividualScheduleUseCase,
-    private val entireSpotScheduleUseCase: EntireSpotScheduleUseCase,
+    private val queryEntireSpotScheduleUseCase: QueryEntireSpotScheduleUseCase,
     private val addSpotScheduleUseCase: AddSpotScheduleUseCase,
     private val changeSpotScheduleUseCase: ChangeSpotScheduleUseCase,
     private val removeSpotScheduleUseCase: RemoveSpotScheduleUseCase
@@ -79,8 +79,8 @@ class WebScheduleAdapter(
     }
 
     @GetMapping("/spots")
-    fun entireSpotSchedule(@RequestParam date: LocalDate) : EntireSpotScheduleResponse {
-        return entireSpotScheduleUseCase.execute(date)
+    fun entireSpotSchedule(@RequestParam date: LocalDate) : QueryEntireSpotScheduleResponse {
+        return queryEntireSpotScheduleUseCase.execute(date)
     }
 
     @PostMapping("/spots/{spot-id}")

--- a/simtong-presentation/src/main/kotlin/team/comit/simtong/domain/schedule/WebScheduleAdapter.kt
+++ b/simtong-presentation/src/main/kotlin/team/comit/simtong/domain/schedule/WebScheduleAdapter.kt
@@ -16,6 +16,7 @@ import team.comit.simtong.domain.schedule.dto.AddSpotScheduleRequest
 import team.comit.simtong.domain.schedule.dto.ChangeIndividualScheduleRequest
 import team.comit.simtong.domain.schedule.dto.ChangeSpotScheduleRequest
 import team.comit.simtong.domain.schedule.dto.QueryEntireSpotScheduleResponse
+import team.comit.simtong.domain.schedule.dto.QueryIndividualSpotScheduleResponse
 import team.comit.simtong.domain.schedule.dto.request.AddIndividualScheduleWebRequest
 import team.comit.simtong.domain.schedule.dto.request.AddSpotScheduleWebRequest
 import team.comit.simtong.domain.schedule.dto.request.ChangeIndividualScheduleWebRequest
@@ -25,10 +26,12 @@ import team.comit.simtong.domain.schedule.usecase.AddSpotScheduleUseCase
 import team.comit.simtong.domain.schedule.usecase.ChangeIndividualScheduleUseCase
 import team.comit.simtong.domain.schedule.usecase.ChangeSpotScheduleUseCase
 import team.comit.simtong.domain.schedule.usecase.QueryEntireSpotScheduleUseCase
+import team.comit.simtong.domain.schedule.usecase.QueryIndividualSpotScheduleUseCase
 import team.comit.simtong.domain.schedule.usecase.RemoveSpotScheduleUseCase
 import java.time.LocalDate
 import java.util.UUID
 import javax.validation.Valid
+import javax.validation.constraints.NotNull
 
 /**
  *
@@ -46,7 +49,8 @@ class WebScheduleAdapter(
     private val queryEntireSpotScheduleUseCase: QueryEntireSpotScheduleUseCase,
     private val addSpotScheduleUseCase: AddSpotScheduleUseCase,
     private val changeSpotScheduleUseCase: ChangeSpotScheduleUseCase,
-    private val removeSpotScheduleUseCase: RemoveSpotScheduleUseCase
+    private val removeSpotScheduleUseCase: RemoveSpotScheduleUseCase,
+    private val queryIndividualSpotScheduleUseCase: QueryIndividualSpotScheduleUseCase
 ) {
 
     @PostMapping
@@ -64,8 +68,9 @@ class WebScheduleAdapter(
 
     @PutMapping("/{schedule-id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    fun changeIndividualSchedule(@PathVariable("schedule-id") scheduleId: UUID,
-                                 @Valid @RequestBody request: ChangeIndividualScheduleWebRequest
+    fun changeIndividualSchedule(
+        @PathVariable("schedule-id") scheduleId: UUID,
+        @Valid @RequestBody request: ChangeIndividualScheduleWebRequest
     ) {
         changeIndividualScheduleUseCase.execute(
             ChangeIndividualScheduleRequest(
@@ -78,15 +83,21 @@ class WebScheduleAdapter(
         )
     }
 
+    @GetMapping
+    fun queryIndividualSpotSchedule(@RequestParam @NotNull date: LocalDate): QueryIndividualSpotScheduleResponse {
+        return queryIndividualSpotScheduleUseCase.execute(date)
+    }
+
     @GetMapping("/spots")
-    fun entireSpotSchedule(@RequestParam date: LocalDate) : QueryEntireSpotScheduleResponse {
+    fun entireSpotSchedule(@RequestParam @NotNull date: LocalDate): QueryEntireSpotScheduleResponse {
         return queryEntireSpotScheduleUseCase.execute(date)
     }
 
     @PostMapping("/spots/{spot-id}")
     @ResponseStatus(HttpStatus.CREATED)
-    fun addSpotSchedule(@PathVariable("spot-id") spotId: UUID,
-                        @Valid @RequestBody request: AddSpotScheduleWebRequest
+    fun addSpotSchedule(
+        @PathVariable("spot-id") spotId: UUID,
+        @Valid @RequestBody request: AddSpotScheduleWebRequest
     ) {
         addSpotScheduleUseCase.execute(
             AddSpotScheduleRequest(
@@ -100,8 +111,9 @@ class WebScheduleAdapter(
 
     @PutMapping("/spots/{schedule-id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    fun changeSpotSchedule(@PathVariable("schedule-id") scheduleId: UUID,
-                           @Valid @RequestBody request: ChangeSpotScheduleWebRequest
+    fun changeSpotSchedule(
+        @PathVariable("schedule-id") scheduleId: UUID,
+        @Valid @RequestBody request: ChangeSpotScheduleWebRequest
     ) {
         changeSpotScheduleUseCase.execute(
             ChangeSpotScheduleRequest(

--- a/simtong-presentation/src/main/kotlin/team/comit/simtong/domain/schedule/WebScheduleAdapter.kt
+++ b/simtong-presentation/src/main/kotlin/team/comit/simtong/domain/schedule/WebScheduleAdapter.kt
@@ -1,6 +1,7 @@
 package team.comit.simtong.domain.schedule
 
 import org.springframework.http.HttpStatus
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -41,6 +42,7 @@ import javax.validation.constraints.NotNull
  * @date 2022/11/21
  * @version 1.0.0
  **/
+@Validated
 @RestController
 @RequestMapping("/schedules")
 class WebScheduleAdapter(


### PR DESCRIPTION
## 작업 내용 설명
- [x] QueryIndividualSpotScheduleUseCase 

## 주요 변경 사항
- Query String에 누락된 @NotNull 추가
- dateFilter로 한 달치 필터링 로직 분리
- EntireSpotSchedule~~ -> QueryEntireSpotSchedule~~

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #166 