### PR TITLE
merge: (#188) 메뉴 저장 API

### DIFF
--- a/simtong-application/src/main/kotlin/team/comit/simtong/domain/file/spi/ParseEmployeeCertificateFilePort.kt
+++ b/simtong-application/src/main/kotlin/team/comit/simtong/domain/file/spi/ParseEmployeeCertificateFilePort.kt
@@ -5,13 +5,13 @@ import java.io.File
 
 /**
  *
- * 파일 분석을 요청하는 ParseFilePort
+ * EmployeeCertificate 파일 파싱을 요청하는 ParseEmployeeCertificateFilePort
  *
  * @author Chokyunghyeon
  * @date 2022/12/06
  * @version 1.0.0
  **/
-interface ParseFilePort {
+interface ParseEmployeeCertificateFilePort {
 
     fun importEmployeeCertificate(file: File): List<EmployeeCertificate>
 }

--- a/simtong-application/src/main/kotlin/team/comit/simtong/domain/file/usecase/RegisterEmployeeCertificateUseCase.kt
+++ b/simtong-application/src/main/kotlin/team/comit/simtong/domain/file/usecase/RegisterEmployeeCertificateUseCase.kt
@@ -1,7 +1,7 @@
 package team.comit.simtong.domain.file.usecase
 
 import team.comit.simtong.domain.file.spi.CommandEmployeeCertificatePort
-import team.comit.simtong.domain.file.spi.ParseFilePort
+import team.comit.simtong.domain.file.spi.ParseEmployeeCertificateFilePort
 import team.comit.simtong.global.annotation.UseCase
 import java.io.File
 
@@ -16,11 +16,11 @@ import java.io.File
 @UseCase
 class RegisterEmployeeCertificateUseCase(
     private val commandEmployeeCertificatePort: CommandEmployeeCertificatePort,
-    private val parseFilePort: ParseFilePort
+    private val parseEmployeeCertificateFilePort: ParseEmployeeCertificateFilePort
 ) {
 
     fun execute(file: File) {
-        val employeeList = parseFilePort.importEmployeeCertificate(file)
+        val employeeList = parseEmployeeCertificateFilePort.importEmployeeCertificate(file)
 
         commandEmployeeCertificatePort.saveAll(employeeList)
     }

--- a/simtong-application/src/main/kotlin/team/comit/simtong/domain/menu/spi/CommandMenuPort.kt
+++ b/simtong-application/src/main/kotlin/team/comit/simtong/domain/menu/spi/CommandMenuPort.kt
@@ -1,0 +1,17 @@
+package team.comit.simtong.domain.menu.spi
+
+import team.comit.simtong.domain.menu.model.Menu
+
+/**
+ *
+ * Menu Domain에 관한 명령을 요청하는 CommandMenuPort
+ *
+ * @author kimbeomjin
+ * @date 2022/12/10
+ * @version 1.0.0
+ **/
+interface CommandMenuPort {
+
+    fun saveAll(menus: List<Menu>)
+
+}

--- a/simtong-application/src/main/kotlin/team/comit/simtong/domain/menu/spi/MenuPort.kt
+++ b/simtong-application/src/main/kotlin/team/comit/simtong/domain/menu/spi/MenuPort.kt
@@ -8,5 +8,5 @@ package team.comit.simtong.domain.menu.spi
  * @date 2022/09/21
  * @version 1.0.0
  **/
-interface MenuPort : QueryMenuPort {
+interface MenuPort : QueryMenuPort, CommandMenuPort {
 }

--- a/simtong-application/src/main/kotlin/team/comit/simtong/domain/menu/spi/ParseMenuFilePort.kt
+++ b/simtong-application/src/main/kotlin/team/comit/simtong/domain/menu/spi/ParseMenuFilePort.kt
@@ -1,0 +1,19 @@
+package team.comit.simtong.domain.menu.spi
+
+import team.comit.simtong.domain.menu.model.Menu
+import java.io.File
+import java.util.UUID
+
+/**
+ *
+ * Menu 파일 파싱을 요청하는 ParseMenuFilePort
+ *
+ * @author kimbeomjin
+ * @date 2022/12/10
+ * @version 1.0.0
+ **/
+interface ParseMenuFilePort {
+
+    fun importMenu(file: File, year: Int, month: Int, spotId: UUID): List<Menu>
+
+}

--- a/simtong-application/src/main/kotlin/team/comit/simtong/domain/menu/usecase/SaveMenuUseCase.kt
+++ b/simtong-application/src/main/kotlin/team/comit/simtong/domain/menu/usecase/SaveMenuUseCase.kt
@@ -1,0 +1,28 @@
+package team.comit.simtong.domain.menu.usecase
+
+import team.comit.simtong.domain.menu.spi.CommandMenuPort
+import team.comit.simtong.domain.menu.spi.ParseMenuFilePort
+import team.comit.simtong.global.annotation.UseCase
+import java.io.File
+import java.util.UUID
+
+/**
+ *
+ * 지점별로 월별 메뉴를 저장을 담당하는 SaveMenuUseCase
+ *
+ * @author kimbeomjin
+ * @date 2022/12/10
+ * @version 1.0.0
+ **/
+@UseCase
+class SaveMenuUseCase(
+    private val parseMenuFilePort: ParseMenuFilePort,
+    private val commandMenuPort: CommandMenuPort
+) {
+
+    fun execute(file: File, year: Int, month: Int, spotId: UUID) {
+        val menu = parseMenuFilePort.importMenu(file, year, month, spotId)
+
+        commandMenuPort.saveAll(menu)
+    }
+}

--- a/simtong-application/src/main/kotlin/team/comit/simtong/domain/menu/usecase/SaveMenuUseCase.kt
+++ b/simtong-application/src/main/kotlin/team/comit/simtong/domain/menu/usecase/SaveMenuUseCase.kt
@@ -1,9 +1,12 @@
 package team.comit.simtong.domain.menu.usecase
 
+import team.comit.simtong.domain.menu.exception.MenuAlreadyExistsSameMonthException
 import team.comit.simtong.domain.menu.spi.CommandMenuPort
 import team.comit.simtong.domain.menu.spi.ParseMenuFilePort
+import team.comit.simtong.domain.menu.spi.QueryMenuPort
 import team.comit.simtong.global.annotation.UseCase
 import java.io.File
+import java.time.LocalDate
 import java.util.UUID
 
 /**
@@ -17,11 +20,16 @@ import java.util.UUID
 @UseCase
 class SaveMenuUseCase(
     private val parseMenuFilePort: ParseMenuFilePort,
+    private val queryMenuPort: QueryMenuPort,
     private val commandMenuPort: CommandMenuPort
 ) {
 
     fun execute(file: File, year: Int, month: Int, spotId: UUID) {
         val menu = parseMenuFilePort.importMenu(file, year, month, spotId)
+
+        if (queryMenuPort.queryMenusByMonthAndSpotId(LocalDate.of(year, month, 1), spotId).isNotEmpty()) {
+            throw MenuAlreadyExistsSameMonthException.EXCEPTION
+        }
 
         commandMenuPort.saveAll(menu)
     }

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/file/usecase/RegisterEmployeeCertificateUseCaseTest.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/file/usecase/RegisterEmployeeCertificateUseCaseTest.kt
@@ -7,7 +7,7 @@ import org.mockito.kotlin.given
 import org.springframework.boot.test.mock.mockito.MockBean
 import team.comit.simtong.domain.file.model.EmployeeCertificate
 import team.comit.simtong.domain.file.spi.CommandEmployeeCertificatePort
-import team.comit.simtong.domain.file.spi.ParseFilePort
+import team.comit.simtong.domain.file.spi.ParseEmployeeCertificateFilePort
 import team.comit.simtong.global.annotation.SimtongTest
 import java.io.File
 
@@ -18,7 +18,7 @@ class RegisterEmployeeCertificateUseCaseTest {
     private lateinit var commandEmployeeCertificatePort: CommandEmployeeCertificatePort
 
     @MockBean
-    private lateinit var parseFilePort: ParseFilePort
+    private lateinit var parseEmployeeCertificateFilePort: ParseEmployeeCertificateFilePort
 
     private lateinit var registerEmployeeCertificateUseCase: RegisterEmployeeCertificateUseCase
 
@@ -39,14 +39,14 @@ class RegisterEmployeeCertificateUseCaseTest {
     fun setUp() {
         registerEmployeeCertificateUseCase = RegisterEmployeeCertificateUseCase(
             commandEmployeeCertificatePort = commandEmployeeCertificatePort,
-            parseFilePort = parseFilePort
+            parseEmployeeCertificateFilePort = parseEmployeeCertificateFilePort
         )
     }
 
     @Test
     fun `사원 명부 등록 성공`() {
         // given
-        given(parseFilePort.importEmployeeCertificate(fileStub))
+        given(parseEmployeeCertificateFilePort.importEmployeeCertificate(fileStub))
             .willReturn(employeeCertificateList)
 
         // when & then

--- a/simtong-application/src/test/kotlin/team/comit/simtong/domain/menu/usecase/SaveMenuUseCaseTests.kt
+++ b/simtong-application/src/test/kotlin/team/comit/simtong/domain/menu/usecase/SaveMenuUseCaseTests.kt
@@ -1,0 +1,60 @@
+package team.comit.simtong.domain.menu.usecase
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.mockito.kotlin.given
+import org.springframework.boot.test.mock.mockito.MockBean
+import team.comit.simtong.domain.menu.model.Menu
+import team.comit.simtong.domain.menu.spi.CommandMenuPort
+import team.comit.simtong.domain.menu.spi.ParseMenuFilePort
+import team.comit.simtong.global.annotation.SimtongTest
+import java.io.File
+import java.time.LocalDate
+import java.util.UUID
+
+@SimtongTest
+class SaveMenuUseCaseTests {
+
+    @MockBean
+    private lateinit var parseMenuFilePort: ParseMenuFilePort
+
+    @MockBean
+    private lateinit var commandMenuPort: CommandMenuPort
+
+    private lateinit var saveMenuUseCase: SaveMenuUseCase
+
+    private val fileStub = File("")
+    private val year = 2022
+    private val month = 12
+    private val spotId = UUID.randomUUID()
+
+    private val menuStub: Menu by lazy {
+        Menu(
+            date = LocalDate.of(year, month, 1),
+            meal = "오늘 아침은 아침밥",
+            spotId = UUID.randomUUID()
+        )
+    }
+
+    @BeforeEach
+    fun setUp() {
+        saveMenuUseCase = SaveMenuUseCase(
+            parseMenuFilePort = parseMenuFilePort,
+            commandMenuPort = commandMenuPort
+        )
+    }
+
+    @Test
+    fun `메뉴 저장 성공`() {
+        // given
+        given(parseMenuFilePort.importMenu(fileStub, year, month, spotId))
+            .willReturn(listOf(menuStub))
+
+        // when & then
+        assertDoesNotThrow {
+            saveMenuUseCase.execute(fileStub, year, month, spotId)
+        }
+    }
+
+}

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/menu/error/MenuErrorCode.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/menu/error/MenuErrorCode.kt
@@ -15,7 +15,7 @@ enum class MenuErrorCode(
     private val message: String
 ) : ErrorProperty {
 
-
+    ALREADY_EXISTS_SAME_MONTH(400, "같은 달에 메뉴가 이미 존재합니다.")
     ;
 
     override fun status(): Int = status

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/menu/exception/MenuAlreadyExistsSameMonthException.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/menu/exception/MenuAlreadyExistsSameMonthException.kt
@@ -1,0 +1,21 @@
+package team.comit.simtong.domain.menu.exception
+
+import team.comit.simtong.domain.menu.error.MenuErrorCode
+import team.comit.simtong.global.error.BusinessException
+
+/**
+ *
+ * 같은 달에 메뉴가 이미 존재하는 경우 발생시키는 MenuAlreadyExistsSameMonthException
+ *
+ * @author kimbeomjin
+ * @date 2022/12/11
+ * @version 1.0.0
+ **/
+class MenuAlreadyExistsSameMonthException private constructor() :
+    BusinessException(MenuErrorCode.ALREADY_EXISTS_SAME_MONTH) {
+
+    companion object {
+        @JvmField
+        val EXCEPTION = MenuAlreadyExistsSameMonthException()
+    }
+}

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/global/security/SecurityConfig.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/global/security/SecurityConfig.kt
@@ -70,6 +70,7 @@ class SecurityConfig(
 
             // menu
             .antMatchers(HttpMethod.GET, "/menu/public").permitAll()
+            .antMatchers(HttpMethod.POST, "/menu").permitAll()
 
             // files
             .antMatchers(HttpMethod.POST, "/files").permitAll()

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/menu/MenuPersistenceAdapter.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/menu/MenuPersistenceAdapter.kt
@@ -8,6 +8,7 @@ import team.comit.simtong.domain.menu.spi.MenuPort
 import team.comit.simtong.persistence.QuerydslExtensionUtils.sameMonthFilter
 import team.comit.simtong.persistence.menu.entity.QMenuJpaEntity.menuJpaEntity
 import team.comit.simtong.persistence.menu.mapper.MenuMapper
+import team.comit.simtong.persistence.menu.repository.MenuJpaRepository
 import team.comit.simtong.persistence.spot.entity.QSpotJpaEntity.spotJpaEntity
 import java.time.LocalDate
 import java.util.UUID
@@ -24,6 +25,7 @@ import java.util.UUID
 @Component
 class MenuPersistenceAdapter(
     private val menuMapper: MenuMapper,
+    private val menuRepository: MenuJpaRepository,
     private val queryFactory: JPAQueryFactory
 ) : MenuPort {
 
@@ -51,6 +53,12 @@ class MenuPersistenceAdapter(
             .orderBy(menuJpaEntity.id.date.asc())
             .fetch()
             .map { menuMapper.toDomain(it)!! }
+    }
+
+    override fun saveAll(menus: List<Menu>) {
+        menuRepository.saveAll(
+            menus.map(menuMapper::toEntity)
+        )
     }
 
     private fun sameMonthMenuFilter(date: LocalDate) : BooleanExpression {

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/menu/MenuPersistenceAdapter.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/menu/MenuPersistenceAdapter.kt
@@ -37,7 +37,7 @@ class MenuPersistenceAdapter(
             .where(
                 sameMonthMenuFilter(date)
             )
-            .orderBy(menuJpaEntity.id.date.asc())
+            .orderBy(menuJpaEntity.menuId.date.asc())
             .fetch()
             .map { menuMapper.toDomain(it)!! }
     }
@@ -50,7 +50,7 @@ class MenuPersistenceAdapter(
             .where(
                 sameMonthMenuFilter(date)
             )
-            .orderBy(menuJpaEntity.id.date.asc())
+            .orderBy(menuJpaEntity.menuId.date.asc())
             .fetch()
             .map { menuMapper.toDomain(it)!! }
     }
@@ -62,7 +62,7 @@ class MenuPersistenceAdapter(
     }
 
     private fun sameMonthMenuFilter(date: LocalDate) : BooleanExpression {
-        return menuJpaEntity.id.date.sameMonthFilter(date)
+        return menuJpaEntity.menuId.date.sameMonthFilter(date)
     }
 
 }

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/menu/entity/MenuJpaEntity.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/menu/entity/MenuJpaEntity.kt
@@ -1,5 +1,6 @@
 package team.comit.simtong.persistence.menu.entity
 
+import org.springframework.data.domain.Persistable
 import team.comit.simtong.persistence.spot.entity.SpotJpaEntity
 import javax.persistence.EmbeddedId
 import javax.persistence.Entity
@@ -7,6 +8,8 @@ import javax.persistence.FetchType
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 import javax.persistence.MapsId
+import javax.persistence.PostLoad
+import javax.persistence.PrePersist
 import javax.persistence.Table
 import javax.validation.constraints.NotNull
 
@@ -23,7 +26,7 @@ import javax.validation.constraints.NotNull
 class MenuJpaEntity(
 
     @EmbeddedId
-    val id: MenuId,
+    val menuId: MenuId,
 
     @field:NotNull
     val meal: String,
@@ -32,4 +35,21 @@ class MenuJpaEntity(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "spot_id", columnDefinition = "BINARY(16)", nullable = false)
     val spot: SpotJpaEntity
-)
+) : Persistable<MenuId> {
+    @Transient
+    private var isNew = true
+
+    override fun getId(): MenuId {
+        return menuId
+    }
+
+    override fun isNew(): Boolean {
+        return isNew
+    }
+
+    @PrePersist
+    @PostLoad
+    fun markNotNew() {
+        isNew = false
+    }
+}

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/menu/mapper/MenuMapper.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/menu/mapper/MenuMapper.kt
@@ -24,14 +24,14 @@ abstract class MenuMapper : GenericMapper<MenuJpaEntity, Menu> {
     protected lateinit var spotJpaRepository: SpotJpaRepository
 
     @Mappings(
-        Mapping(target = "id", expression = "java(new MenuId(model.getSpotId(), model.getDate()))"),
+        Mapping(target = "menuId", expression = "java(new MenuId(model.getSpotId(), model.getDate()))"),
         Mapping(target = "spot", expression = "java(spotJpaRepository.findById(model.getSpotId()).orElse(null))")
     )
     abstract override fun toEntity(model: Menu): MenuJpaEntity
 
     @Mappings(
-        Mapping(target = "spotId", expression = "java(entity.getId().getSpotId())"),
-        Mapping(target = "date", expression = "java(entity.getId().getDate())")
+        Mapping(target = "spotId", expression = "java(entity.getMenuId().getSpotId())"),
+        Mapping(target = "date", expression = "java(entity.getMenuId().getDate())")
     )
     abstract override fun toDomain(entity: MenuJpaEntity?): Menu?
 

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/thirdparty/parser/ExcelFileAdapter.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/thirdparty/parser/ExcelFileAdapter.kt
@@ -65,12 +65,17 @@ class ExcelFileAdapter : ParseEmployeeCertificateFilePort, ParseMenuFilePort {
         runCatching {
             val workSheet = workbook.getSheetAt(0)
 
-            // cell 2+3, 5+6, 8+9 .. -> 문자열 더하기
-            // cell 4, 7, 10 .. -> 무시
-            for (rowNum in 2 until workSheet.lastRowNum step 3) {
+            // cell 1, 4, 7, 10 .. -> 날짜
+            // cell 2+3, 5+6, 8+9 .. -> 메뉴
+            for (rowNum in 1 until workSheet.lastRowNum step 3) {
+
+                val dayRow = workSheet.getRow(rowNum)
+                val mealRow = workSheet.getRow(rowNum + 1)
+                val dessertRow = workSheet.getRow(rowNum + 2)
+
                 for (cellNum in 0..6) {
-                    var meal = workSheet.getRow(rowNum)
-                        .getCell(cellNum, CREATE_NULL_AS_BLANK).stringCellValue
+
+                    var meal = mealRow.getCell(cellNum, CREATE_NULL_AS_BLANK).stringCellValue
                         .replace("\n", ",") // 줄바꿈 기준으로 ,로 구분
 
                     /**
@@ -80,15 +85,13 @@ class ExcelFileAdapter : ParseEmployeeCertificateFilePort, ParseMenuFilePort {
                         continue
                     }
 
-                    val dessert = workSheet.getRow(rowNum + 1)
-                        .getCell(cellNum, CREATE_NULL_AS_BLANK).stringCellValue
+                    val dessert = dessertRow.getCell(cellNum, CREATE_NULL_AS_BLANK).stringCellValue
 
-                    if (dessert.isNotEmpty()) {
+                    if (dessert.isNotEmpty()) { // 디저트가 있다면 문자열 합치기
                         meal = "$meal,$dessert"
                     }
 
-                    val day = workSheet.getRow(rowNum - 1)
-                        .getCell(cellNum, CREATE_NULL_AS_BLANK).stringCellValue
+                    val day = dayRow.getCell(cellNum, CREATE_NULL_AS_BLANK).stringCellValue
                         .substringBeforeLast("(") // 숫자만 가져오기 ex. 1(월) -> 1
                         .toInt()
 

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/thirdparty/parser/ExcelFileAdapter.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/thirdparty/parser/ExcelFileAdapter.kt
@@ -11,24 +11,30 @@ import team.comit.simtong.domain.file.converter.FileExtensions.XLSX
 import team.comit.simtong.domain.file.exception.FileInvalidExtensionException
 import team.comit.simtong.domain.file.exception.FileNotValidContentException
 import team.comit.simtong.domain.file.model.EmployeeCertificate
-import team.comit.simtong.domain.file.spi.ParseFilePort
+import team.comit.simtong.domain.file.spi.ParseEmployeeCertificateFilePort
+import team.comit.simtong.domain.menu.model.Menu
+import team.comit.simtong.domain.menu.spi.ParseMenuFilePort
 import java.io.File
+import java.time.LocalDate
+import java.util.UUID
 
 /**
  *
- * 엑셀 파일 구문 분석을 담당하는 ExcelFileAdapter
+ * 엑셀 파일 구문 파싱을 담당하는 ExcelFileAdapter
  *
  * @author Chokyunghyeon
+ * @author kimbeomjin
  * @date 2022/12/06
  * @version 1.0.0
  **/
 @Component
-class ExcelFileAdapter : ParseFilePort {
+class ExcelFileAdapter : ParseEmployeeCertificateFilePort, ParseMenuFilePort {
 
     override fun importEmployeeCertificate(file: File): List<EmployeeCertificate> {
         val workbook = transferToExcel(file)
 
         val employeeCertificateList = mutableListOf<EmployeeCertificate>()
+
         runCatching {
             val workSheet = workbook.getSheetAt(0)
 
@@ -44,14 +50,66 @@ class ExcelFileAdapter : ParseFilePort {
 
                 employeeCertificateList.add(employeeData)
             }
-        }.onFailure {
+        }.onFailure { e ->
+            e.printStackTrace()
             throw FileNotValidContentException.EXCEPTION
         }
 
         return employeeCertificateList
     }
 
-    private fun transferToExcel(file: File) : Workbook {
+    override fun importMenu(file: File, year: Int, month: Int, spotId: UUID): List<Menu> {
+        val workbook = transferToExcel(file)
+        val menu = mutableListOf<Menu>()
+
+        runCatching {
+            val workSheet = workbook.getSheetAt(0)
+
+            // cell 2+3, 5+6, 8+9 .. -> 문자열 더하기
+            // cell 4, 7, 10 .. -> 무시
+            for (rowNum in 2 until workSheet.lastRowNum step 3) {
+                for (cellNum in 0..6) {
+                    var meal = workSheet.getRow(rowNum)
+                        .getCell(cellNum, CREATE_NULL_AS_BLANK).stringCellValue
+                        .replace("\n", ",") // 줄바꿈 기준으로 ,로 구분
+
+                    /**
+                     * 메뉴가 없는 경우 다음 cell로 이동
+                     */
+                    if (meal.isEmpty()) {
+                        continue
+                    }
+
+                    val dessert = workSheet.getRow(rowNum + 1)
+                        .getCell(cellNum, CREATE_NULL_AS_BLANK).stringCellValue
+
+                    if (dessert.isNotEmpty()) {
+                        meal = "$meal,$dessert"
+                    }
+
+                    val day = workSheet.getRow(rowNum - 1)
+                        .getCell(cellNum, CREATE_NULL_AS_BLANK).stringCellValue
+                        .substringBeforeLast("(") // 숫자만 가져오기 ex. 1(월) -> 1
+                        .toInt()
+
+                    val menuData = Menu(
+                        date = LocalDate.of(year, month, day),
+                        meal = meal,
+                        spotId = spotId,
+                    )
+
+                    menu.add(menuData)
+                }
+            }
+        }.onFailure { e ->
+            e.printStackTrace()
+            throw FileNotValidContentException.EXCEPTION
+        }
+
+        return menu
+    }
+
+    private fun transferToExcel(file: File): Workbook {
         val inputStream = file.inputStream()
 
         return runCatching {

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/thirdparty/storage/AwsS3Adapter.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/thirdparty/storage/AwsS3Adapter.kt
@@ -30,8 +30,10 @@ class AwsS3Adapter(
     override fun upload(file: File): String {
         runCatching { inputS3(file) }
             .also { file.delete() }
-            .onFailure { throw it }
-
+            .onFailure { e ->
+                e.printStackTrace()
+                throw e
+            }
 
         return getResource(file.name)
     }
@@ -39,7 +41,10 @@ class AwsS3Adapter(
     override fun upload(files: List<File>): List<String> {
         runCatching { files.forEach(::inputS3) }
             .also { files.forEach(File::delete) }
-            .onFailure { throw it }
+            .onFailure { e ->
+                e.printStackTrace()
+                throw e
+            }
 
         return files.map { getResource(it.name) }
     }
@@ -61,6 +66,7 @@ class AwsS3Adapter(
                 ).withCannedAcl(CannedAccessControlList.PublicRead)
             )
         } catch (e: IOException) {
+            e.printStackTrace()
             throw FileIOInterruptedException.EXCEPTION
         }
     }

--- a/simtong-infrastructure/src/main/resources/application-dev.yml
+++ b/simtong-infrastructure/src/main/resources/application-dev.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:mysql://${DB_URL:localhost}:3306/${DB_NAME:simtong}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+    url: jdbc:mysql://${DB_URL:localhost}:3306/${DB_NAME:simtong}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&rewriteBatchedStatements=true
     username: ${MYSQL_USERNAME}
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -12,6 +12,10 @@ spring:
       hibernate:
         format_sql: true
         show_sql: true
+        jdbc:
+          batch_size: 50
+        order_inserts: true
+        order_updates: true
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
     open-in-view: false
 

--- a/simtong-infrastructure/src/main/resources/application-prod.yml
+++ b/simtong-infrastructure/src/main/resources/application-prod.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:mysql://${DB_URL}:3306/${DB_NAME}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+    url: jdbc:mysql://${DB_URL}:3306/${DB_NAME}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&rewriteBatchedStatements=true
     username: ${MYSQL_USERNAME}
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -12,6 +12,10 @@ spring:
       hibernate:
         format_sql: ${FORMAT_SQL:false}
         show_sql: ${SHOW_SQL:false}
+      jdbc:
+        batch_size: 50
+      order_inserts: true
+      order_updates: true
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
     open-in-view: false
 

--- a/simtong-infrastructure/src/test/kotlin/team/comit/simtong/thirdparty/storage/AwsS3AdapterTests.kt
+++ b/simtong-infrastructure/src/test/kotlin/team/comit/simtong/thirdparty/storage/AwsS3AdapterTests.kt
@@ -79,13 +79,28 @@ class AwsS3AdapterTests {
     }
 
     @Test
-    fun `파일 입출력 오류`() {
+    fun `단일 파일 입출력 오류`() {
         // given
         val file = File("test.jpg")
 
         // when & then
         assertThrows<FileIOInterruptedException> {
             awsS3Adapter.upload(file)
+        }
+    }
+
+    @Test
+    fun `다중 파일 입출력 오류`() {
+        // given
+        val files = listOf(
+            File("test.jpg"),
+            File("test.jpeg"),
+            File("test.png")
+        )
+
+        // when & then
+        assertThrows<FileIOInterruptedException> {
+            awsS3Adapter.upload(files)
         }
     }
 

--- a/simtong-presentation/src/main/kotlin/team/comit/simtong/domain/menu/WebMenuAdapter.kt
+++ b/simtong-presentation/src/main/kotlin/team/comit/simtong/domain/menu/WebMenuAdapter.kt
@@ -1,13 +1,18 @@
 package team.comit.simtong.domain.menu
 
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+import team.comit.simtong.domain.file.converter.ExcelFileConverter
 import team.comit.simtong.domain.menu.dto.MenuResponse
 import team.comit.simtong.domain.menu.usecase.QueryMenuByMonthUseCase
 import team.comit.simtong.domain.menu.usecase.QueryPublicMenuUseCase
+import team.comit.simtong.domain.menu.usecase.SaveMenuUseCase
 import java.time.LocalDate
+import java.util.UUID
 
 /**
  *
@@ -22,7 +27,8 @@ import java.time.LocalDate
 @RequestMapping("/menu")
 class WebMenuAdapter(
     private val queryMenuByMonthUseCase: QueryMenuByMonthUseCase,
-    private val queryPublicMenuUseCase: QueryPublicMenuUseCase
+    private val queryPublicMenuUseCase: QueryPublicMenuUseCase,
+    private val saveMenuUseCase: SaveMenuUseCase
 ) {
 
     @GetMapping
@@ -39,4 +45,18 @@ class WebMenuAdapter(
         return queryPublicMenuUseCase.execute(date)
     }
 
+    @PostMapping
+    fun saveMenu(
+        file: MultipartFile,
+        @RequestParam year: Int,
+        @RequestParam month: Int,
+        @RequestParam spotId: UUID,
+    ) {
+        saveMenuUseCase.execute(
+            file = file.let(ExcelFileConverter::transferTo),
+            year = year,
+            month = month,
+            spotId = spotId
+        )
+    }
 }


### PR DESCRIPTION
## 작업 내용 설명
- [x] SaveMenuUseCase
- [x] CommandMenuPort
- [x] ParseMenuFilePort

## 주요 변경 사항
- ParseFilePort -> ParseEmployeeCertificateFilePort
- SaveMenuUseCase permission
- external api 예외 발생 시 printStackTrace
- MenuJpaEntity 저장 시 persist 메서드 사용하도록 적용
- Batch Insert 적용

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [x] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #188 