### PR TITLE
merge: (#291) mapper 직접 구현

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -36,10 +36,6 @@ object Dependencies {
     // jwt
     const val JWT = "io.jsonwebtoken:jjwt:${DependencyVersions.JWT_VERSION}"
 
-    // mapstruct
-    const val MAPSTRUCT = "org.mapstruct:mapstruct:${DependencyVersions.MAPSTRUCT_VERSION}"
-    const val MAPSTRUCT_PROCESSOR = "org.mapstruct:mapstruct-processor:${DependencyVersions.MAPSTRUCT_VERSION}"
-
     // aws
     const val SPRING_AWS = "org.springframework.cloud:spring-cloud-starter-aws:${DependencyVersions.AWS_VERSION}"
     const val AWS_SES = "com.amazonaws:aws-java-sdk-ses:${DependencyVersions.AWS_SES_VERSION}"

--- a/buildSrc/src/main/kotlin/DependencyVersions.kt
+++ b/buildSrc/src/main/kotlin/DependencyVersions.kt
@@ -1,6 +1,5 @@
 object DependencyVersions {
     const val JWT_VERSION = "0.9.1"
-    const val MAPSTRUCT_VERSION = "1.5.2.Final"
     const val AWS_VERSION = "2.2.6.RELEASE"
     const val REDIS_VERSION = "2.7.2"
     const val SERVLET = "4.0.1"

--- a/simtong-domain/src/main/kotlin/team/comit/simtong/domain/user/model/User.kt
+++ b/simtong-domain/src/main/kotlin/team/comit/simtong/domain/user/model/User.kt
@@ -3,6 +3,7 @@ package team.comit.simtong.domain.user.model
 import team.comit.simtong.global.DomainProperties.getProperty
 import team.comit.simtong.global.DomainPropertiesPrefix
 import team.comit.simtong.global.annotation.Aggregate
+import java.time.LocalDateTime
 import java.util.UUID
 
 /**
@@ -34,7 +35,9 @@ data class User(
 
     val teamId: UUID,
 
-    val profileImagePath: String
+    val profileImagePath: String,
+
+    val deletedAt: LocalDateTime? = null
 ) {
 
     companion object {

--- a/simtong-infrastructure/build.gradle.kts
+++ b/simtong-infrastructure/build.gradle.kts
@@ -37,10 +37,6 @@ dependencies {
     implementation(Dependencies.SPRING_AWS)
     implementation(Dependencies.AWS_SES)
 
-    // mapstruct
-    implementation(Dependencies.MAPSTRUCT)
-    kapt(Dependencies.MAPSTRUCT_PROCESSOR)
-
     // read-file
     implementation(Dependencies.COMMONS_IO)
     implementation(Dependencies.POI)

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/auth/mapper/AuthCodeLimitMapper.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/auth/mapper/AuthCodeLimitMapper.kt
@@ -1,6 +1,6 @@
 package team.comit.simtong.persistence.auth.mapper
 
-import org.mapstruct.Mapper
+import org.springframework.stereotype.Component
 import team.comit.simtong.domain.auth.model.AuthCodeLimit
 import team.comit.simtong.persistence.GenericMapper
 import team.comit.simtong.persistence.auth.entity.AuthCodeLimitEntity
@@ -12,8 +12,37 @@ import team.comit.simtong.persistence.auth.entity.AuthCodeLimitEntity
  * @author Chokyunghyeon
  * @author kimbeomjin
  * @date 2022/09/11
- * @version 1.0.0
+ * @version 1.2.5
  **/
-@Mapper
-abstract class AuthCodeLimitMapper : GenericMapper<AuthCodeLimitEntity, AuthCodeLimit> {
+@Component
+class AuthCodeLimitMapper : GenericMapper<AuthCodeLimitEntity, AuthCodeLimit> {
+
+    override fun toEntity(model: AuthCodeLimit): AuthCodeLimitEntity {
+        return AuthCodeLimitEntity(
+            key = model.key,
+            expirationTime = model.expirationTime,
+            attemptCount = model.attemptCount,
+            verified = model.verified
+        )
+    }
+
+    override fun toDomain(entity: AuthCodeLimitEntity?): AuthCodeLimit? {
+        return entity?.let {
+            AuthCodeLimit(
+                key = it.key,
+                expirationTime = it.expirationTime,
+                attemptCount = it.attemptCount,
+                verified = it.verified
+            )
+        }
+    }
+
+    override fun toDomainNotNull(entity: AuthCodeLimitEntity): AuthCodeLimit {
+        return AuthCodeLimit(
+            key = entity.key,
+            expirationTime = entity.expirationTime,
+            attemptCount = entity.attemptCount,
+            verified = entity.verified
+        )
+    }
 }

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/auth/mapper/RefreshTokenMapper.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/auth/mapper/RefreshTokenMapper.kt
@@ -1,6 +1,6 @@
 package team.comit.simtong.persistence.auth.mapper
 
-import org.mapstruct.Mapper
+import org.springframework.stereotype.Component
 import team.comit.simtong.domain.auth.model.RefreshToken
 import team.comit.simtong.persistence.GenericMapper
 import team.comit.simtong.persistence.auth.entity.RefreshTokenEntity
@@ -10,9 +10,39 @@ import team.comit.simtong.persistence.auth.entity.RefreshTokenEntity
  * RefreshTokenEntity와 DomainRefreshToken을 변환하는 RefreshTokenMapper
  *
  * @author Chokyunghyeon
+ * @author kimbeomjin
  * @date 2022/09/18
- * @version 1.0.0
+ * @version 1.2.5
  **/
-@Mapper
-abstract class RefreshTokenMapper : GenericMapper<RefreshTokenEntity, RefreshToken> {
+@Component
+class RefreshTokenMapper : GenericMapper<RefreshTokenEntity, RefreshToken> {
+
+    override fun toEntity(model: RefreshToken): RefreshTokenEntity {
+        return RefreshTokenEntity(
+            token = model.token,
+            userId = model.userId,
+            authority = model.authority,
+            expirationTime = model.expirationTime
+        )
+    }
+
+    override fun toDomain(entity: RefreshTokenEntity?): RefreshToken? {
+        return entity?.let {
+            RefreshToken(
+                token = it.token,
+                userId = it.userId,
+                authority = it.authority,
+                expirationTime = it.expirationTime
+            )
+        }
+    }
+
+    override fun toDomainNotNull(entity: RefreshTokenEntity): RefreshToken {
+        return RefreshToken(
+            token = entity.token,
+            userId = entity.userId,
+            authority = entity.authority,
+            expirationTime = entity.expirationTime
+        )
+    }
 }

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/file/mapper/EmployeeCertificateMapper.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/file/mapper/EmployeeCertificateMapper.kt
@@ -1,6 +1,6 @@
 package team.comit.simtong.persistence.file.mapper
 
-import org.mapstruct.Mapper
+import org.springframework.stereotype.Component
 import team.comit.simtong.domain.file.model.EmployeeCertificate
 import team.comit.simtong.persistence.GenericMapper
 import team.comit.simtong.persistence.file.entity.EmployeeCertificateJpaEntity
@@ -10,9 +10,39 @@ import team.comit.simtong.persistence.file.entity.EmployeeCertificateJpaEntity
  * EmployeeCertificate Entity와 Employee Certificate Aggregate를 변환하는 EmployeeCertificateMapper
  *
  * @author Chokyunghyeon
+ * @author kimbeomjin
  * @date 2022/12/06
- * @version 1.0.0
+ * @version 1.2.5
  **/
-@Mapper
-abstract class EmployeeCertificateMapper : GenericMapper<EmployeeCertificateJpaEntity, EmployeeCertificate> {
+@Component
+class EmployeeCertificateMapper : GenericMapper<EmployeeCertificateJpaEntity, EmployeeCertificate> {
+
+    override fun toEntity(model: EmployeeCertificate): EmployeeCertificateJpaEntity {
+        return EmployeeCertificateJpaEntity(
+            employeeNumber = model.employeeNumber,
+            name = model.name,
+            spotName = model.spotName,
+            teamName = model.teamName
+        )
+    }
+
+    override fun toDomain(entity: EmployeeCertificateJpaEntity?): EmployeeCertificate? {
+        return entity?.let {
+            EmployeeCertificate(
+                employeeNumber = it.employeeNumber,
+                name = it.name,
+                spotName = it.spotName,
+                teamName = it.teamName
+            )
+        }
+    }
+
+    override fun toDomainNotNull(entity: EmployeeCertificateJpaEntity): EmployeeCertificate {
+        return EmployeeCertificate(
+            employeeNumber = entity.employeeNumber,
+            name = entity.name,
+            spotName = entity.spotName,
+            teamName = entity.teamName
+        )
+    }
 }

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/holiday/mapper/HolidayMapper.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/holiday/mapper/HolidayMapper.kt
@@ -1,9 +1,7 @@
 package team.comit.simtong.persistence.holiday.mapper
 
-import org.mapstruct.Mapper
-import org.mapstruct.Mapping
-import org.mapstruct.Mappings
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
 import team.comit.simtong.domain.holiday.model.Holiday
 import team.comit.simtong.persistence.GenericMapper
 import team.comit.simtong.persistence.holiday.entity.HolidayJpaEntity
@@ -15,36 +13,53 @@ import team.comit.simtong.persistence.user.repository.UserJpaRepository
  * 휴무일 엔티티와 도메인 휴무일 변환을 담당하는 HolidayMapper
  *
  * @author Chokyunghyeon
+ * @author kimbeomjin
  * @date 2022/12/02
- * @version 1.2.3
+ * @version 1.2.5
  **/
-@Mapper
-abstract class HolidayMapper : GenericMapper<HolidayJpaEntity, Holiday> {
+@Component
+class HolidayMapper(
+    private val userJpaRepository: UserJpaRepository,
+    private val spotJpaRepository: SpotJpaRepository
+) : GenericMapper<HolidayJpaEntity, Holiday> {
 
-    @Autowired
-    protected lateinit var userJpaRepository: UserJpaRepository
+    override fun toEntity(model: Holiday): HolidayJpaEntity {
+        val user = userJpaRepository.findByIdOrNull(model.userId)!!
+        val spot = spotJpaRepository.findByIdOrNull(model.spotId)!!
 
-    @Autowired
-    protected lateinit var spotJpaRepository: SpotJpaRepository
+        return HolidayJpaEntity(
+            id = HolidayJpaEntity.Id(
+                userId = model.userId,
+                date = model.date
+            ),
+            type = model.type,
+            user = user,
+            spot = spot,
+            status = model.status
+        )
+    }
 
-    @Mappings(
-        Mapping(target = "userId", expression = "java(entity.getId().getUserId())"),
-        Mapping(target = "spotId", expression = "java(entity.getSpot().getId())"),
-        Mapping(target = "date", expression = "java(entity.getId().getDate())")
-    )
-    abstract override fun toDomain(entity: HolidayJpaEntity?): Holiday?
+    override fun toDomain(entity: HolidayJpaEntity?): Holiday? {
+        return entity?.let {
+            val id = it.id
+            Holiday(
+                date = id.date,
+                userId = id.userId,
+                type = it.type,
+                spotId = it.spot.id!!,
+                status = it.status
+            )
+        }
+    }
 
-    @Mappings(
-        Mapping(target = "userId", expression = "java(entity.getId().getUserId())"),
-        Mapping(target = "spotId", expression = "java(entity.getSpot().getId())"),
-        Mapping(target = "date", expression = "java(entity.getId().getDate())")
-    )
-    abstract override fun toDomainNotNull(entity: HolidayJpaEntity): Holiday
-
-    @Mappings(
-        Mapping(target = "user", expression = "java(userJpaRepository.findById(model.getUserId()).orElse(null))"),
-        Mapping(target = "spot", expression = "java(spotJpaRepository.findById(model.getSpotId()).orElse(null))"),
-        Mapping(target = "id", expression = "java(new HolidayJpaEntity.Id(model.getDate(), model.getUserId()))")
-    )
-    abstract override fun toEntity(model: Holiday): HolidayJpaEntity
+    override fun toDomainNotNull(entity: HolidayJpaEntity): Holiday {
+        val id = entity.id
+        return Holiday(
+            date = id.date,
+            userId = id.userId,
+            type = entity.type,
+            spotId = entity.spot.id!!,
+            status = entity.status
+        )
+    }
 }

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/notification/mapper/NotificationMapper.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/notification/mapper/NotificationMapper.kt
@@ -1,6 +1,6 @@
 package team.comit.simtong.persistence.notification.mapper
 
-import org.mapstruct.Mapper
+import org.springframework.stereotype.Component
 import team.comit.simtong.domain.notification.model.Notification
 import team.comit.simtong.persistence.GenericMapper
 import team.comit.simtong.persistence.notification.entity.NotificationJpaEntity
@@ -11,8 +11,42 @@ import team.comit.simtong.persistence.notification.entity.NotificationJpaEntity
  *
  * @author kimbeomjin
  * @date 2022/12/29
- * @version 1.1.0
+ * @version 1.2.5
  **/
-@Mapper
-abstract class NotificationMapper : GenericMapper<NotificationJpaEntity, Notification> {
+@Component
+class NotificationMapper : GenericMapper<NotificationJpaEntity, Notification> {
+    override fun toEntity(model: Notification): NotificationJpaEntity {
+        return NotificationJpaEntity(
+            id = model.id,
+            title = model.title,
+            content = model.content,
+            type = model.type,
+            identify = model.identify,
+            createdAt = model.createdAt
+        )
+    }
+
+    override fun toDomain(entity: NotificationJpaEntity?): Notification? {
+        return entity?.let {
+            Notification(
+                id = it.id,
+                title = it.title,
+                content = it.content,
+                type = it.type,
+                identify = it.identify,
+                createdAt = it.createdAt
+            )
+        }
+    }
+
+    override fun toDomainNotNull(entity: NotificationJpaEntity): Notification {
+        return Notification(
+            id = entity.id,
+            title = entity.title,
+            content = entity.content,
+            type = entity.type,
+            identify = entity.identify,
+            createdAt = entity.createdAt
+        )
+    }
 }

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/notification/mapper/NotificationReceiverMapper.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/notification/mapper/NotificationReceiverMapper.kt
@@ -1,9 +1,7 @@
 package team.comit.simtong.persistence.notification.mapper
 
-import org.mapstruct.Mapper
-import org.mapstruct.Mapping
-import org.mapstruct.Mappings
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
 import team.comit.simtong.domain.notification.model.NotificationReceiver
 import team.comit.simtong.persistence.GenericMapper
 import team.comit.simtong.persistence.notification.entity.NotificationReceiverJpaEntity
@@ -16,43 +14,44 @@ import team.comit.simtong.persistence.user.repository.UserJpaRepository
  *
  * @author kimbeomjin
  * @date 2022/12/29
- * @version 1.2.3
+ * @version 1.2.5
  **/
-@Mapper
-abstract class NotificationReceiverMapper : GenericMapper<NotificationReceiverJpaEntity, NotificationReceiver> {
+@Component
+class NotificationReceiverMapper(
+    private val userJpaRepository: UserJpaRepository,
+    private val notificationJpaRepository: NotificationJpaRepository
+) : GenericMapper<NotificationReceiverJpaEntity, NotificationReceiver> {
 
-    @Autowired
-    protected lateinit var notificationRepository: NotificationJpaRepository
+    override fun toEntity(model: NotificationReceiver): NotificationReceiverJpaEntity {
+        val user = userJpaRepository.findByIdOrNull(model.userId)!!
+        val notification = notificationJpaRepository.findByIdOrNull(model.notificationId)!!
 
-    @Autowired
-    protected lateinit var userRepository: UserJpaRepository
-
-    @Mappings(
-        Mapping(
-            target = "notificationReceiverId",
-            expression = "java(new NotificationReceiverJpaEntity.Id(model.getUserId(), model.getNotificationId()))"
-        ),
-        Mapping(
-            target = "user",
-            expression = "java(userRepository.findById(model.getUserId()).orElse(null))"
-        ),
-        Mapping(
-            target = "notification",
-            expression = "java(notificationRepository.findById(model.getNotificationId()).orElse(null))"
+        return NotificationReceiverJpaEntity(
+            notificationReceiverId = NotificationReceiverJpaEntity.Id(
+                userId = model.userId,
+                notificationId = model.notificationId
+            ),
+            user = user,
+            notification = notification,
+            checkedAt = model.checkedAt
         )
-    )
-    abstract override fun toEntity(model: NotificationReceiver): NotificationReceiverJpaEntity
+    }
 
-    @Mappings(
-        Mapping(target = "userId", expression = "java(entity.getNotificationReceiverId().getUserId())"),
-        Mapping(target = "notificationId", expression = "java(entity.getNotificationReceiverId().getNotificationId())")
-    )
-    abstract override fun toDomain(entity: NotificationReceiverJpaEntity?): NotificationReceiver?
+    override fun toDomain(entity: NotificationReceiverJpaEntity?): NotificationReceiver? {
+        return entity?.let {
+            NotificationReceiver(
+                userId = it.user.id!!,
+                notificationId = it.notification.id,
+                checkedAt = it.checkedAt
+            )
+        }
+    }
 
-    @Mappings(
-        Mapping(target = "userId", expression = "java(entity.getNotificationReceiverId().getUserId())"),
-        Mapping(target = "notificationId", expression = "java(entity.getNotificationReceiverId().getNotificationId())")
-    )
-    abstract override fun toDomainNotNull(entity: NotificationReceiverJpaEntity): NotificationReceiver
-
+    override fun toDomainNotNull(entity: NotificationReceiverJpaEntity): NotificationReceiver {
+        return NotificationReceiver(
+            userId = entity.user.id!!,
+            notificationId = entity.notification.id,
+            checkedAt = entity.checkedAt
+        )
+    }
 }

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/spot/mapper/SpotMapper.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/spot/mapper/SpotMapper.kt
@@ -1,6 +1,6 @@
 package team.comit.simtong.persistence.spot.mapper
 
-import org.mapstruct.Mapper
+import org.springframework.stereotype.Component
 import team.comit.simtong.domain.spot.model.Spot
 import team.comit.simtong.persistence.GenericMapper
 import team.comit.simtong.persistence.spot.entity.SpotJpaEntity
@@ -10,9 +10,36 @@ import team.comit.simtong.persistence.spot.entity.SpotJpaEntity
  * SpotEntity와 DomainSpot을 변환하는 SpotMapper
  *
  * @author Chokyunghyeon
+ * @author kimbeomjin
  * @date 2022/09/18
- * @version 1.0.0
+ * @version 1.2.5
  **/
-@Mapper
-abstract class SpotMapper : GenericMapper<SpotJpaEntity, Spot> {
+@Component
+class SpotMapper : GenericMapper<SpotJpaEntity, Spot> {
+
+    override fun toEntity(model: Spot): SpotJpaEntity {
+        return SpotJpaEntity(
+            id = model.id,
+            name = model.name,
+            location = model.location,
+        )
+    }
+
+    override fun toDomain(entity: SpotJpaEntity?): Spot? {
+        return entity?.let {
+            Spot(
+                id = it.id!!,
+                name = it.name,
+                location = it.location
+            )
+        }
+    }
+
+    override fun toDomainNotNull(entity: SpotJpaEntity): Spot {
+        return Spot(
+            id = entity.id!!,
+            name = entity.name,
+            location = entity.location
+        )
+    }
 }

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/team/mapper/TeamMapper.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/team/mapper/TeamMapper.kt
@@ -1,8 +1,7 @@
 package team.comit.simtong.persistence.team.mapper
 
-import org.mapstruct.Mapper
-import org.mapstruct.Mapping
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
 import team.comit.simtong.domain.team.model.Team
 import team.comit.simtong.persistence.GenericMapper
 import team.comit.simtong.persistence.spot.SpotJpaRepository
@@ -13,19 +12,40 @@ import team.comit.simtong.persistence.team.entity.TeamJpaEntity
  * TeamEntity와 DomainTeam을 변환하는 TeamMapper
  *
  * @author Chokyunghyeon
+ * @author kimbeomjin
  * @date 2022/09/18
- * @version 1.0.0
+ * @version 1.2.5
  **/
-@Mapper
-abstract class TeamMapper : GenericMapper<TeamJpaEntity, Team> {
+@Component
+class TeamMapper(
+    private val spotJpaRepository: SpotJpaRepository
+) : GenericMapper<TeamJpaEntity, Team> {
 
-    @Autowired
-    protected lateinit var spotJpaRepository: SpotJpaRepository
+    override fun toEntity(model: Team): TeamJpaEntity {
+        val spot = spotJpaRepository.findByIdOrNull(model.spotId)!!
 
-    @Mapping(target = "spot", expression = "java(spotJpaRepository.findById(model.getSpotId()).orElse(null))")
-    abstract override fun toEntity(model: Team): TeamJpaEntity
+        return TeamJpaEntity(
+            id = model.id,
+            name = model.name,
+            spot = spot
+        )
+    }
 
-    @Mapping(target = "spotId", expression = "java(entity.getSpot().getId())")
-    abstract override fun toDomain(entity: TeamJpaEntity?): Team?
+    override fun toDomain(entity: TeamJpaEntity?): Team? {
+        return entity?.let {
+            Team(
+                id = it.id!!,
+                name = it.name,
+                spotId = it.spot.id!!
+            )
+        }
+    }
 
+    override fun toDomainNotNull(entity: TeamJpaEntity): Team {
+        return Team(
+            id = entity.id!!,
+            name = entity.name,
+            spotId = entity.spot.id!!
+        )
+    }
 }

--- a/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/user/mapper/DeviceTokenMapper.kt
+++ b/simtong-infrastructure/src/main/kotlin/team/comit/simtong/persistence/user/mapper/DeviceTokenMapper.kt
@@ -1,8 +1,7 @@
 package team.comit.simtong.persistence.user.mapper
 
-import org.mapstruct.Mapper
-import org.mapstruct.Mapping
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
 import team.comit.simtong.domain.user.model.DeviceToken
 import team.comit.simtong.persistence.GenericMapper
 import team.comit.simtong.persistence.user.entity.DeviceTokenJpaEntity
@@ -14,14 +13,36 @@ import team.comit.simtong.persistence.user.repository.UserJpaRepository
  *
  * @author kimbeomjin
  * @date 2023/01/01
- * @version 1.1.0
+ * @version 1.2.5
  **/
-@Mapper
-abstract class DeviceTokenMapper : GenericMapper<DeviceTokenJpaEntity, DeviceToken> {
+@Component
+class DeviceTokenMapper(
+    private val userJpaRepository: UserJpaRepository
+) : GenericMapper<DeviceTokenJpaEntity, DeviceToken> {
 
-    @Autowired
-    protected lateinit var userRepository: UserJpaRepository
+    override fun toEntity(model: DeviceToken): DeviceTokenJpaEntity {
+        val user = userJpaRepository.findByIdOrNull(model.userId)!!
 
-    @Mapping(target = "user", expression = "java(userRepository.findById(model.getUserId()).orElse(null))")
-    abstract override fun toEntity(model: DeviceToken): DeviceTokenJpaEntity
+        return DeviceTokenJpaEntity(
+            userId = model.userId,
+            user = user,
+            token = model.token
+        )
+    }
+
+    override fun toDomain(entity: DeviceTokenJpaEntity?): DeviceToken? {
+        return entity?.let {
+            DeviceToken(
+                userId = it.user.id!!,
+                token = it.token
+            )
+        }
+    }
+
+    override fun toDomainNotNull(entity: DeviceTokenJpaEntity): DeviceToken {
+        return DeviceToken(
+            userId = entity.user.id!!,
+            token = entity.token
+        )
+    }
 }


### PR DESCRIPTION
## 작업 내용 설명
- [x] 모든 도메인 매퍼 직접 구현하도록 변경

## 주요 변경 사항
- mapstruct 의존성 삭제
- User Aggregate에 누락된 `deletedAt` 필드 추가

## 체크리스트
- [x] 어플리케이션 구동(혹은 테스트)시 오류는 없나요?
- [x] 생성된 코드에 Javadoc 주석을 추가 하였나요?
- [ ] 생성된 코드에 대한 테스트 코드가 작성 되었나요?

## 관련 이슈
- resolved #291 